### PR TITLE
fix(ci): add explicit github_token to Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           # OAuth token for Claude Code GitHub App authentication
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Explicit GitHub token to bypass OIDC exchange (enables Copilot/bot PRs)
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           use_sticky_comment: true
 


### PR DESCRIPTION
## Summary

- Adds explicit `github_token` input to the Claude Code action to bypass OIDC token exchange
- Enables Claude Code reviews for PRs from GitHub Copilot and other bot accounts

## Problem

The Claude Code action uses OIDC token exchange by default, which requires PR authors to have repository write access. This fails for:
- GitHub Copilot bot PRs
- Other automation/bot accounts without write permissions

## Solution

Add `github_token: ${{ secrets.GITHUB_TOKEN }}` as an explicit input parameter. This bypasses OIDC exchange and uses the built-in workflow token.

**Security note:** The existing `if` condition that skips forked PRs remains in place to protect secrets from untrusted external code.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)