### PR TITLE
feat(permissions): block git -C flag in Claude and Gemini permissions

### DIFF
--- a/.ai-instructions/concepts/workspace-management.md
+++ b/.ai-instructions/concepts/workspace-management.md
@@ -20,6 +20,7 @@ Each project must maintain:
 
 - **Branching**: `main` for production, `feature/*` for development, `experiment/*` for temporary tests.
 - **Commits**: Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+- **Command Execution**: Run git commands directly from the working directory. Do not use `git -C <path>` as it breaks permission pattern matching.
 
 ### Security Standards
 

--- a/.claude/permissions/deny.json
+++ b/.claude/permissions/deny.json
@@ -53,6 +53,7 @@
     "Bash(git rebase --no-verify:*)",
     "Bash(git config core.hooksPath:*)",
     "Bash(git -c core.hooksPath:*)",
+    "Bash(git -C:*)",
     "Bash(pre-commit uninstall:*)",
     "Bash(rm .git/hooks:*)",
     "Bash(rm -rf .git/hooks:*)",

--- a/.gemini/permissions/deny.json
+++ b/.gemini/permissions/deny.json
@@ -1,0 +1,5 @@
+{
+  "coreTools": [
+    "ShellTool(git -C *)"
+  ]
+}


### PR DESCRIPTION
## Summary

Block `git -C` commands at the permission level to prevent AI agents from bypassing permission pattern matching.

- Add `Bash(git -C:*)` deny pattern to Claude permissions
- Create Gemini deny.json with `ShellTool(git -C *)` pattern  
- Add git command execution guidance to workspace-management.md

## Problem

The instruction "Try to maintain your current working directory throughout the session by using absolute paths and avoiding usage of `cd`" causes AI agents to misuse `git -C <path>` flags. This breaks permission pattern matching because patterns like `Bash(git push:*)` do not match commands like `git -C /path push`.

## Research Findings

- **Claude**: Uses `Bash(git -C:*)` syntax with `:*` wildcard
- **Gemini**: Uses `ShellTool(git -C *)` syntax with space before wildcard
- **Copilot**: Does NOT support permission deny lists (relies on instruction-based guidance only)

## Test plan

- [x] Validate JSON syntax with `jq`
- [x] Verify markdown formatting with `markdownlint-cli2`
- [x] Confirm existing git commands (`status`, `diff`, `log`) still work
- [x] Pre-commit hooks pass

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)