### PR TITLE
ci: add markdown link checker workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,11 +10,13 @@ jobs:
   link-check:
     name: "Check Links"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress '**/*.md'
+          args: --verbose --no-progress --exclude 'shields.io' --exclude 'github.com/.*/badge' --accept 429 '**/*.md'
+          output: lychee/out.md
           fail: true


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that automatically checks all markdown files for broken links using the lychee link checker. This will help ensure documentation quality by:
- Detecting broken internal links between documentation files
- Detecting broken external links to third-party resources
- Running on all pushes to main and pull requests

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)