### PR TITLE
ci: add explicit job names to GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude:
+    name: "Claude Code Review"
     # Prevent workflow from running on forked PRs to protect secrets
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   doc-sync:
+    name: "Sync Documentation"
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   triage:
+    name: "Triage New Issue"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   markdownlint-cli2:
+    name: "Lint Markdown Files"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Added explicit `name` fields to all GitHub Actions workflow jobs to make them discoverable in branch protection settings and improve the GitHub UI experience.

### Changes

- `.github/workflows/claude.yml` - Added name "Claude Code Review" to `claude` job
- `.github/workflows/markdownlint.yml` - Added name "Lint Markdown Files" to `markdownlint-cli2` job  
- `.github/workflows/doc-sync.yml` - Added name "Sync Documentation" to `doc-sync` job
- `.github/workflows/issue-triage.yml` - Added name "Triage New Issue" to `triage` job

### Benefits

- Jobs are now discoverable in GitHub's branch protection settings
- Improved readability in the Actions UI
- Consistent naming convention across all workflows

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)