### PR TITLE
feat(cspell): import bundled dictionaries for common tech terms

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,6 +13,8 @@
     "terraform"
   ],
   "words": [
+    "PRRC",
+    "PRRT",
     "anthropic",
     "autofix",
     "autofixes",
@@ -39,8 +41,6 @@
     "oneline",
     "openai",
     "paydown",
-    "PRRC",
-    "PRRT",
     "rankdir",
     "roksechs",
     "styleguide",


### PR DESCRIPTION
## Summary

- Import bundled cspell dictionaries for common tech terminology
- Reduce custom dictionary maintenance burden
- Add project-specific vocabulary for consistent spell checking

## Changes

### Dictionaries Added
- `data-science` - AI/ML/LLM terminology (embeddings, tokenizers, LLM, pretrained, finetuned, etc.)
- `softwareTerms` - Common software development terms (codebase, monorepo, utils, etc.)
- `git` - Git terminology (worktree, symlink, etc.)
- `npm` - NPM/package management terms
- `node` - Node.js terminology
- `docker` - Container terminology
- `k8s` - Kubernetes terminology  
- `terraform` - Infrastructure as Code terms

### Words Removed (Now Covered by Dictionaries)
- `bool`, `codebase`, `frontmatter`, `graphql`, `monorepo`, `repo`, `symlink`, `symlinks`, `terraform`, `utils`

### Words Added (Project-Specific)
- Methodology: `timebox`, `paydown`, `wireframes`
- Tools: `gitmoji`, `hclfmt`, `oneline`
- References: `xkcd`, `lotr`, `subreddits`, `styleguide`
- Contributors: `roksechs`, `kieranklaassen`
- GraphQL IDs: `PRRT`, `PRRC`, `gtge`, `gtged`, `gtgt`, `gtgtb`
- Other: `rankdir`, `toplevel`, `docstrings`

### Configuration
- Added `agent-os` to `ignorePaths` (local development artifacts with usernames in paths)
- Arrays sorted lexicographically (case-sensitive)

## Test Plan

- [x] `npx cspell lint "**/*.md"` passes with 0 issues
- [x] `npx cspell lint ".ai-instructions/**/*.md"` passes with 0 issues
- [x] Pre-commit hooks pass

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)