### PR TITLE
docs: update README command list from 10 to 13 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,16 @@ Full details in [`.ai-instructions/workflows/`](.ai-instructions/workflows/).
 | `/generate-code` | Scaffold new code with standards |
 | `/git-refresh` | Merge PRs, sync repo, cleanup stale worktrees |
 | `/infrastructure-review` | Review Terraform/Terragrunt code |
+| `/init-worktree` | Initialize a clean worktree for development |
 | `/pull-request` | Complete PR lifecycle management |
+| `/pull-request-review-feedback` | Resolve PR review threads via GraphQL |
 | `/review-code` | Structured code review |
 | `/review-docs` | Review and improve documentation |
+| `/sync-permissions` | Sync AI assistant permissions to repo |
 
 **Community commands** (rok-* series): `/rok-shape-issues`, `/rok-resolve-issues`, `/rok-review-pr`, `/rok-respond-to-reviews`
 
-All 10 commands live in [`.ai-instructions/commands/`](.ai-instructions/commands/).
+All 13 commands live in [`.ai-instructions/commands/`](.ai-instructions/commands/).
 
 ## Core Concepts
 


### PR DESCRIPTION
## Summary

- Add missing commands to the Key Commands table in README.md
- Update total command count from 10 to 13 to match actual available commands

## Changes

Added the following commands to the documentation:

| Command | Description |
| ------- | ----------- |
| `/init-worktree` | Initialize a clean worktree for development |
| `/pull-request-review-feedback` | Resolve PR review threads via GraphQL |
| `/sync-permissions` | Sync AI assistant permissions to repo |

Note: The deprecated `/init-change` command is excluded from the count (13 active commands + 1 deprecated = 14 total files).

## Test plan

- [x] Verify markdown lint passes
- [x] Confirm command count matches actual files in `.ai-instructions/commands/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)