### PR TITLE
fix: update all symlinks to point to agentsmd after directory rename

### DIFF
--- a/.claude/SOUL.md
+++ b/.claude/SOUL.md
@@ -1,1 +1,1 @@
-../.ai-instructions/SOUL.md
+../agentsmd/AGENTS.md

--- a/.claude/commands/generate-code.md
+++ b/.claude/commands/generate-code.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/generate-code.md
+../../agentsmd/commands/generate-code.md

--- a/.claude/commands/git-refresh.md
+++ b/.claude/commands/git-refresh.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/git-refresh.md
+../../agentsmd/commands/git-refresh.md

--- a/.claude/commands/infrastructure-review.md
+++ b/.claude/commands/infrastructure-review.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/infrastructure-review.md
+../../agentsmd/commands/infrastructure-review.md

--- a/.claude/commands/init-change.md
+++ b/.claude/commands/init-change.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/init-change.md
+../../agentsmd/commands/init-change.md

--- a/.claude/commands/init-worktree.md
+++ b/.claude/commands/init-worktree.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/init-worktree.md
+../../agentsmd/commands/init-worktree.md

--- a/.claude/commands/pull-request-review-feedback.md
+++ b/.claude/commands/pull-request-review-feedback.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/pull-request-review-feedback.md
+../../agentsmd/commands/pull-request-review-feedback.md

--- a/.claude/commands/pull-request.md
+++ b/.claude/commands/pull-request.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/pull-request.md
+../../agentsmd/commands/pull-request.md

--- a/.claude/commands/review-code.md
+++ b/.claude/commands/review-code.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/review-code.md
+../../agentsmd/commands/review-code.md

--- a/.claude/commands/review-docs.md
+++ b/.claude/commands/review-docs.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/review-docs.md
+../../agentsmd/commands/review-docs.md

--- a/.claude/commands/rok-resolve-issues.md
+++ b/.claude/commands/rok-resolve-issues.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/rok-resolve-issues.md
+../../agentsmd/commands/rok-resolve-issues.md

--- a/.claude/commands/rok-respond-to-reviews.md
+++ b/.claude/commands/rok-respond-to-reviews.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/rok-respond-to-reviews.md
+../../agentsmd/commands/rok-respond-to-reviews.md

--- a/.claude/commands/rok-review-pr.md
+++ b/.claude/commands/rok-review-pr.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/rok-review-pr.md
+../../agentsmd/commands/rok-review-pr.md

--- a/.claude/commands/rok-shape-issues.md
+++ b/.claude/commands/rok-shape-issues.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/rok-shape-issues.md
+../../agentsmd/commands/rok-shape-issues.md

--- a/.claude/commands/sync-permissions.md
+++ b/.claude/commands/sync-permissions.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/sync-permissions.md
+../../agentsmd/commands/sync-permissions.md

--- a/.copilot/ARCHITECTURE.md
+++ b/.copilot/ARCHITECTURE.md
@@ -1,1 +1,1 @@
-../.ai-instructions/concepts/architecture.md
+../agentsmd/rules/architecture.md

--- a/.copilot/PROJECT.md
+++ b/.copilot/PROJECT.md
@@ -1,1 +1,1 @@
-../.ai-instructions/concepts/project-scope.md
+../agentsmd/rules/project-scope.md

--- a/.copilot/WORKSPACE.md
+++ b/.copilot/WORKSPACE.md
@@ -1,1 +1,1 @@
-../.ai-instructions/concepts/workspace-management.md
+../agentsmd/rules/workspace-management.md

--- a/.copilot/instructions.md
+++ b/.copilot/instructions.md
@@ -1,1 +1,1 @@
-../.ai-instructions/INSTRUCTIONS.md
+../agentsmd/AGENTS.md

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,1 +1,1 @@
-../.ai-instructions/concepts/styleguide.md
+../agentsmd/rules/styleguide.md

--- a/.github/.copilot-codeGeneration-instructions.md
+++ b/.github/.copilot-codeGeneration-instructions.md
@@ -1,1 +1,1 @@
-../.ai-instructions/commands/generate-code.md
+../agentsmd/commands/generate-code.md

--- a/.github/.copilot-pull-request-description-instructions.md
+++ b/.github/.copilot-pull-request-description-instructions.md
@@ -1,1 +1,1 @@
-../.ai-instructions/commands/pull-request.md
+../agentsmd/commands/pull-request.md

--- a/.github/.copilot-review-instructions.md
+++ b/.github/.copilot-review-instructions.md
@@ -1,1 +1,1 @@
-../.ai-instructions/commands/review-code.md
+../agentsmd/commands/review-code.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-../.ai-instructions/INSTRUCTIONS.md
+../agentsmd/AGENTS.md

--- a/.github/prompts/generate-code.prompt.md
+++ b/.github/prompts/generate-code.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/generate-code.md
+../../agentsmd/commands/generate-code.md

--- a/.github/prompts/infrastructure-review.prompt.md
+++ b/.github/prompts/infrastructure-review.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/infrastructure-review.md
+../../agentsmd/commands/infrastructure-review.md

--- a/.github/prompts/pull-request-review-feedback.prompt.md
+++ b/.github/prompts/pull-request-review-feedback.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/pull-request-review-feedback.md
+../../agentsmd/commands/pull-request-review-feedback.md

--- a/.github/prompts/pull-request.prompt.md
+++ b/.github/prompts/pull-request.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/pull-request.md
+../../agentsmd/commands/pull-request.md

--- a/.github/prompts/review-code.prompt.md
+++ b/.github/prompts/review-code.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/review-code.md
+../../agentsmd/commands/review-code.md

--- a/.github/prompts/review-docs.prompt.md
+++ b/.github/prompts/review-docs.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/review-docs.md
+../../agentsmd/commands/review-docs.md

--- a/.github/prompts/rok-resolve-issues.prompt.md
+++ b/.github/prompts/rok-resolve-issues.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/rok-resolve-issues.md
+../../agentsmd/commands/rok-resolve-issues.md

--- a/.github/prompts/rok-respond-to-reviews.prompt.md
+++ b/.github/prompts/rok-respond-to-reviews.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/rok-respond-to-reviews.md
+../../agentsmd/commands/rok-respond-to-reviews.md

--- a/.github/prompts/rok-review-pr.prompt.md
+++ b/.github/prompts/rok-review-pr.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/rok-review-pr.md
+../../agentsmd/commands/rok-review-pr.md

--- a/.github/prompts/rok-shape-issues.prompt.md
+++ b/.github/prompts/rok-shape-issues.prompt.md
@@ -1,1 +1,1 @@
-../../.ai-instructions/commands/rok-shape-issues.md
+../../agentsmd/commands/rok-shape-issues.md


### PR DESCRIPTION
## Summary
After the migration from `.ai-instructions` to `agentsmd` in PR #104, 34 symlinks across `.claude/`, `.copilot/`, `.gemini/`, and `.github/` were still pointing to the old directory structure, causing Link Check failures on main.

## Changes
- SOUL.md/INSTRUCTIONS.md symlinks now point to `agentsmd/AGENTS.md`
- Concept symlinks (`.copilot/`, `.gemini/`) now point to `agentsmd/rules/`
- Command symlinks (`.claude/commands/`, `.github/prompts/`) now point to `agentsmd/commands/`

## Validation
- ✅ Replicated Link Check failure locally using `./scripts/identify-symlinks.sh`
- ✅ Fixed all 34 broken symlinks  
- ✅ Verified locally: `has_broken_symlinks=false`
- ✅ Pre-commit hooks pass

## Test plan
- [x] Run `./scripts/identify-symlinks.sh` - shows no broken symlinks
- [x] Pre-commit hooks pass
- [ ] Link Check workflow passes in CI
- [ ] All status checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)