### PR TITLE
docs: remove outdated v0.8.0 session progress from PLANNING.md

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -1,18 +1,5 @@
 # Project Status & Planning
 
-## Current Session Progress (2025-12-03)
-
-Preparing v0.8.0 release - first formal GitHub release:
-
-- ✅ Converted 8 pointer markdown files to proper symlinks
-- ✅ Moved `.copilot/ARCHITECTURE.md` and `PROJECT.md` to `.ai-instructions/concepts/`
-- ✅ Created CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md
-- ✅ Overhauled README.md (26 lines → ~100 lines)
-- ✅ Updated GitHub Actions workflow to use `CLAUDE_CODE_OAUTH_TOKEN`
-- ✅ Staged `.gemini/permissions/` for inclusion in release
-- 🔄 Final lint/cleanup in progress
-- ⏳ GitHub release pending (manual user action)
-
 ## Repository Context
 
 - **Target**: Standardized, vendor-agnostic AI assistant instructions


### PR DESCRIPTION
## Summary

- Remove outdated "Current Session Progress (2025-12-03)" section from PLANNING.md
- v0.8.0 was released on 2025-12-04, so this section is no longer relevant
- Keep only active planning sections: Repository Context, Known Issues, and Future Improvements
- All markdown linting checks pass

## Changes

- Deleted lines 3-15 (completed v0.8.0 session progress)
- No other changes to the file structure or content

## Test plan

- [x] Markdown linting passes (markdownlint-cli2)
- [x] Pre-commit hooks pass
- [x] File structure remains valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)