### PR TITLE
fix: correct symlink target for fix-all-pr-ci.prompt.md (Issue #111)

### DIFF
--- a/.github/prompts/fix-all-pr-ci.prompt.md
+++ b/.github/prompts/fix-all-pr-ci.prompt.md
@@ -1,1 +1,1 @@
-../../agentsmd/commands/fix-all-pr-ci-all-repos.md
+../../agentsmd/commands/fix-all-pr-ci.md


### PR DESCRIPTION
## Summary
- Fix broken symlink `.github/prompts/fix-all-pr-ci.prompt.md`
- Old target: `../../agentsmd/commands/fix-all-pr-ci-all-repos.md` (does not exist)
- New target: `../../agentsmd/commands/fix-all-pr-ci.md` (exists and is correct)

## Changes
- Remove broken symlink
- Create correct symlink pointing to existing file

## Verification
- Tested symlink resolves correctly: ✓
- Git shows file as modified (not empty commit): ✓

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)