### PR TITLE
fix: correct relative paths in sub-agent documentation files

### DIFF
--- a/.claude/sub-agents/code/code-generator.md
+++ b/.claude/sub-agents/code/code-generator.md
@@ -25,7 +25,7 @@ Designed to be invoked by other commands or agents for focused code generation t
 
 ### Quality Standards
 
-Follow [Code Standards](../../agentsmd/rules/code-standards.md):
+Follow [Code Standards](../../../agentsmd/rules/code-standards.md):
 
 - **Readability**: Clear, self-documenting code
 - **Naming**: Descriptive, concise names for all identifiers
@@ -551,7 +551,7 @@ If requirements are unclear or ambiguous:
 
 ## Related Documentation
 
-- [Code Standards](../../agentsmd/rules/code-standards.md)
-- [DRY Principle](../../agentsmd/rules/dry-principle.md)
-- [Styleguide](../../agentsmd/rules/styleguide.md)
-- [generate-code Command](../../agentsmd/commands/generate-code.md)
+- [Code Standards](../../../agentsmd/rules/code-standards.md)
+- [DRY Principle](../../../agentsmd/rules/dry-principle.md)
+- [Styleguide](../../../agentsmd/rules/styleguide.md)
+- [generate-code Command](../../../agentsmd/commands/generate-code.md)

--- a/.claude/sub-agents/issue/issue-resolver.md
+++ b/.claude/sub-agents/issue/issue-resolver.md
@@ -33,7 +33,7 @@ Designed to be invoked by orchestration commands for autonomous issue implementa
 
 ### Implementation Quality
 
-- Follow [Code Standards](../../agentsmd/rules/code-standards.md)
+- Follow [Code Standards](../../../agentsmd/rules/code-standards.md)
 - Write clean, maintainable, well-documented code
 - Ensure backward compatibility unless breaking change is required
 - Follow existing patterns and architectural conventions
@@ -169,7 +169,7 @@ npm test
 
 ### Step 6: Implement Solution
 
-Follow [Code Standards](../../agentsmd/rules/code-standards.md):
+Follow [Code Standards](../../../agentsmd/rules/code-standards.md):
 
 - **Clear naming**: Descriptive variable/function names
 - **Modularity**: Single responsibility per module
@@ -415,7 +415,7 @@ If unable to complete after reasonable effort:
 
 ## Related Documentation
 
-- [Code Standards](../../agentsmd/rules/code-standards.md)
-- [Worktrees](../../agentsmd/rules/worktrees.md)
-- [Subagent Parallelization](../../agentsmd/rules/subagent-parallelization.md)
-- [rok-resolve-issues Command](../../agentsmd/commands/rok-resolve-issues.md)
+- [Code Standards](../../../agentsmd/rules/code-standards.md)
+- [Worktrees](../../../agentsmd/rules/worktrees.md)
+- [Subagent Parallelization](../../../agentsmd/rules/subagent-parallelization.md)
+- [rok-resolve-issues Command](../../../agentsmd/commands/rok-resolve-issues.md)

--- a/.claude/sub-agents/pr/ci-fixer.md
+++ b/.claude/sub-agents/pr/ci-fixer.md
@@ -352,6 +352,6 @@ If unable to fix after 3 attempts:
 
 ## Related Documentation
 
-- [Code Standards](../../agentsmd/rules/code-standards.md)
-- [Worktrees](../../agentsmd/rules/worktrees.md)
-- [Subagent Parallelization](../../agentsmd/rules/subagent-parallelization.md)
+- [Code Standards](../../../agentsmd/rules/code-standards.md)
+- [Worktrees](../../../agentsmd/rules/worktrees.md)
+- [Subagent Parallelization](../../../agentsmd/rules/subagent-parallelization.md)

--- a/.claude/sub-agents/pr/thread-resolver.md
+++ b/.claude/sub-agents/pr/thread-resolver.md
@@ -468,6 +468,6 @@ If unable to resolve a thread:
 
 ## Related Documentation
 
-- [PR Review Thread Resolver Command](../../agentsmd/commands/rok-resolve-pr-review-thread.md)
-- [Code Standards](../../agentsmd/rules/code-standards.md)
-- [Subagent Parallelization](../../agentsmd/rules/subagent-parallelization.md)
+- [PR Review Thread Resolver Command](../../../agentsmd/commands/rok-resolve-pr-review-thread.md)
+- [Code Standards](../../../agentsmd/rules/code-standards.md)
+- [Subagent Parallelization](../../../agentsmd/rules/subagent-parallelization.md)

--- a/.claude/sub-agents/review/code-reviewer.md
+++ b/.claude/sub-agents/review/code-reviewer.md
@@ -23,9 +23,9 @@ Can be invoked by other commands or agents for focused code analysis.
 
 This sub-agent applies:
 
-- [Code Standards](../../agentsmd/rules/code-standards.md)
-- [Infrastructure Standards](../../agentsmd/rules/infrastructure-standards.md)
-- [Styleguide](../../agentsmd/rules/styleguide.md)
+- [Code Standards](../../../agentsmd/rules/code-standards.md)
+- [Infrastructure Standards](../../../agentsmd/rules/infrastructure-standards.md)
+- [Styleguide](../../../agentsmd/rules/styleguide.md)
 
 ## Review Focus Areas
 

--- a/.claude/sub-agents/review/docs-reviewer.md
+++ b/.claude/sub-agents/review/docs-reviewer.md
@@ -92,10 +92,10 @@ Check:
 
 ### 5. Project Standards Compliance
 
-- Follow [Documentation Standards](../../agentsmd/rules/documentation-standards.md)
+- Follow [Documentation Standards](../../../agentsmd/rules/documentation-standards.md)
 - Use hierarchical numbering (1., 1.1., 1.1.1.) for AI-trackable structure
 - Ensure AI-first writing (concise, structured)
-- Verify adherence to [DRY Principle](../../agentsmd/rules/dry-principle.md)
+- Verify adherence to [DRY Principle](../../../agentsmd/rules/dry-principle.md)
 - Link to other documents instead of repeating information
 
 ### 6. AI-Friendly Formatting
@@ -109,9 +109,9 @@ Check:
 
 Update if needed:
 
-- [Technical Context](../../agentsmd/rules/memory-bank/technical-context.md)
-- [Project Brief](../../agentsmd/rules/memory-bank/project-brief.md)
-- [Progress Tracking](../../agentsmd/rules/memory-bank/progress-tracking.md)
+- [Technical Context](../../../agentsmd/rules/memory-bank/technical-context.md)
+- [Project Brief](../../../agentsmd/rules/memory-bank/project-brief.md)
+- [Progress Tracking](../../../agentsmd/rules/memory-bank/progress-tracking.md)
 
 ### 8. Link Validation
 

--- a/.claude/sub-agents/review/infrastructure-reviewer.md
+++ b/.claude/sub-agents/review/infrastructure-reviewer.md
@@ -243,7 +243,7 @@ Focus: Modularity, tagging, documentation
 
 This sub-agent applies:
 
-- [Infrastructure Standards](../../agentsmd/rules/infrastructure-standards.md)
+- [Infrastructure Standards](../../../agentsmd/rules/infrastructure-standards.md)
 - AWS Well-Architected Framework
 - Terraform best practices
 - Terragrunt conventions


### PR DESCRIPTION
## Summary

Fixed broken relative paths in 7 sub-agent markdown files. These files are located 3 levels deep in the `.claude/sub-agents/` directory structure and require 3 levels of relative path traversal (`../../../`) to reach the repository root where `agentsmd/` is located.

## Changes

Updated the following files with corrected relative paths from `../../agentsmd/` to `../../../agentsmd/`:

- `.claude/sub-agents/review/infrastructure-reviewer.md`
- `.claude/sub-agents/review/code-reviewer.md`
- `.claude/sub-agents/review/docs-reviewer.md`
- `.claude/sub-agents/issue/issue-resolver.md`
- `.claude/sub-agents/pr/thread-resolver.md`
- `.claude/sub-agents/pr/ci-fixer.md`
- `.claude/sub-agents/code/code-generator.md`

All internal links now correctly resolve to their target files in the `agentsmd/` directory.

## Testing

- All pre-commit hooks passed (markdownlint-cli2 validation successful)
- All 26 link references updated and verified to point to existing files
- No content changes, only path corrections

## Impact

This fix resolves Link Check CI workflow failures on main branch by ensuring all relative links in sub-agent documentation files are valid.

Generated with Claude Code

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>