### PR TITLE
fix: correct broken documentation links

### DIFF
--- a/.claude/sub-agents/util/dependency-checker.md
+++ b/.claude/sub-agents/util/dependency-checker.md
@@ -671,6 +671,5 @@ Try:
 
 ## Related Documentation
 
-- [Code Standards](../../../agentsmd/rules/code-standards.md) - Dependency management standards
-- [Security Guidelines](../../../agentsmd/rules/security.md) - Security best practices
+- [Code Standards](../../../agentsmd/rules/code-standards.md) - Dependency management standards and security practices
 - [CI Fixer Sub-Agent](../pr/ci-fixer.md) - Automated CI failure resolution

--- a/agentsmd/docs/claude-code-session-naming.md
+++ b/agentsmd/docs/claude-code-session-naming.md
@@ -324,7 +324,7 @@ If you have many sessions, adopt these strategies:
 ## Related Resources
 
 - [Claude Code Docs - CLI Reference](https://code.claude.com/docs/en/cli-reference)
-- [Worktrees Guide](./worktrees.md) - For managing git worktrees alongside sessions
+- [Worktrees Guide](../rules/worktrees.md) - For managing git worktrees alongside sessions
 - [Branch Hygiene](../rules/branch-hygiene.md) - For syncing branches with sessions
 
 ## Summary


### PR DESCRIPTION
## Summary
- Fixed relative path in `agentsmd/docs/claude-code-session-naming.md` (line 327): Changed `./worktrees.md` to `../rules/worktrees.md`
- Removed broken link to non-existent `agentsmd/rules/security.md` in `.claude/sub-agents/util/dependency-checker.md` (line 675) and consolidated security info into Code Standards reference

## Test Plan
- [x] Verify both target files exist at their referenced paths
- [x] Confirmed `agentsmd/rules/worktrees.md` exists
- [x] Confirmed `agentsmd/rules/code-standards.md` exists
- [x] Pre-commit hooks passed (markdownlint-cli2)

Closes #175