### PR TITLE
docs: Remove broken external links from sandbox-evaluation.md

### DIFF
--- a/agentsmd/docs/sandbox-evaluation.md
+++ b/agentsmd/docs/sandbox-evaluation.md
@@ -25,7 +25,7 @@ For higher security requirements (untrusted code execution), combine native sand
 
 #### How It Works
 
-- **macOS:** Uses built-in [Seatbelt](https://developer.apple.com/documentation/security/seatbelt) sandbox
+- **macOS:** Uses built-in Seatbelt sandbox
 - **Linux:** Uses [bubblewrap](https://github.com/containers/bubblewrap) for application sandboxing
 - **Windows:** Filesystem virtualization (limited isolation)
 
@@ -522,11 +522,7 @@ A: Credentials follow normal file system rules. Use OS keychain for sensitive va
 
 - [Claude Code Sandboxing Documentation](https://code.claude.com/docs/en/sandboxing)
 - [Docker AI Sandboxes - Get Started](https://docs.docker.com/ai/sandboxes/get-started/)
-- [Apple Seatbelt Documentation](https://developer.apple.com/documentation/security/seatbelt)
 - [bubblewrap - Container Isolation](https://github.com/containers/bubblewrap)
-- [Running Claude Code Agents in Docker][medium-docker-claude]
-
-[medium-docker-claude]: https://medium.com/@dan.avila7/running-claude-code-agents-in-docker-containers-for-complete-isolation-63036a2ef6f4
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Fixed two broken external links in `agentsmd/docs/sandbox-evaluation.md`:

- **Apple Seatbelt documentation** (`https://developer.apple.com/documentation/security/seatbelt`) - Returns 404 Not Found
- **Medium article** (`https://medium.com/@dan.avila7/running-claude-code-agents-in-docker-containers-for-complete-isolation-63036a2ef6f4`) - Returns 403 Forbidden

These links were not accessible and provided minimal value to the documentation.

## Changes

- Removed the hyperlink from "Seatbelt" reference in the macOS section (kept the text for clarity)
- Removed the Apple Seatbelt documentation reference from the References section
- Removed the Medium article reference and its URL definition

## Test Plan

- Verified that markdownlint passes
- Verified that documentation still provides adequate information about sandbox options
- Verified all working references remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)