### PR TITLE
fix: resolve shellcheck warnings in select-model.sh

### DIFF
--- a/scripts/select-model.sh
+++ b/scripts/select-model.sh
@@ -79,7 +79,8 @@ analyze_complexity() {
   else
     # Text-based analysis
     text_length=${#input}
-    local lower_input=$(echo "$input" | tr '[:upper:]' '[:lower:]')
+    local lower_input
+    lower_input=$(echo "$input" | tr '[:upper:]' '[:lower:]')
 
     # Check for complexity keywords
     local keyword_count=0
@@ -145,7 +146,7 @@ select_model() {
         ;;
       decision)
         echo "Model: deepseek-r1:70b + qwen3-next:80b"
-        echo "Command: bash -c 'echo \"Model 1 (DeepSeek R1):\" && ollama run deepseek-r1:70b && echo -e \"\\nModel 2 (Qwen):\\\" && ollama run qwen3-next:80b'"
+        printf "Command: bash -c 'echo \"Model 1 (DeepSeek R1):\" && ollama run deepseek-r1:70b && echo -e \"\\\\nModel 2 (Qwen):\\\" && ollama run qwen3-next:80b'\n"
         echo "Rationale: Cost-sensitive critical decision - using best-reasoning + general local models"
         return 0
         ;;


### PR DESCRIPTION
## Summary

Fixed two shellcheck warnings in scripts/select-model.sh:

- SC2155: Declare local variable separately from assignment to avoid masking return values
  - Line 82: Split `local lower_input=$(...)` into separate declaration and assignment
  
- SC2028: Use printf instead of echo for escape sequences
  - Line 148: Changed `echo` with escape sequences to `printf` for proper handling

## Test Plan

- [x] Run shellcheck to verify no warnings remain
- [x] Verified shell script still executes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)