### PR TITLE
fix: remove references to non-existent commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,9 +103,8 @@ All commands from `agentsmd/commands/` are available. Use this table to select t
 | Sync all PRs with main | `/sync-main-all` | Repo | Update main, merge into all open PRs |
 | Sync PRs with main | `/sync-prs-with-main` | Repo | Superseded by `/sync-main-all` |
 | Fix PR CI failures | `/fix-pr-ci` | Repo | Fix CI in current repo |
-| Fix all PR CI failures | `/fix-all-pr-ci-all-repos` | All repos | Fix CI across all owned repos |
+| Fix all PR CI failures | `/fix-all-pr-ci` | Repo | Fix all CI failures in current repo |
 | Resolve PR review threads | `/resolve-pr-review-thread-all` | Repo | Address review comments in current repo |
-| Resolve PR reviews (all repos) | `/resolve-pr-review-thread-all-repos` | All repos | Cross-repo review resolution |
 | Sync repo, merge PRs | `/git-refresh` | Repo | Also cleans worktrees |
 | Create a GitHub issue | `/rok-shape-issues` | Repo | Shape before creating |
 | Implement an issue | `/rok-resolve-issues` | Repo | For shaped issues |

--- a/README.md
+++ b/README.md
@@ -99,9 +99,8 @@ Full details in [`agentsmd/workflows/`](agentsmd/workflows/).
 | `/pr` | Complete PR lifecycle management |
 | `/pr-review-feedback` | Resolve PR review threads via GraphQL |
 | `/fix-pr-ci` | Fix CI failures in current repo |
-| `/fix-all-pr-ci-all-repos` | Fix CI failures across all owned repos |
+| `/fix-all-pr-ci` | Fix all CI failures in current repo |
 | `/resolve-pr-review-thread-all` | Address review comments in current repo |
-| `/resolve-pr-review-thread-all-repos` | Address review comments across all repos |
 
 ### Issue & Architecture Management
 


### PR DESCRIPTION
## Summary

Remove documentation references to `/fix-all-pr-ci-all-repos` and `/resolve-pr-review-thread-all-repos` commands which do not exist in the codebase.

These non-existent commands were referenced in:
- AGENTS.md (which CLAUDE.md symlinks to)
- README.md

Actual available commands are:
- `/fix-all-pr-ci` - for fixing CI failures in current repository
- `/resolve-pr-review-thread-all` - for addressing review comments in current repository

## Changes

- Remove rows from command tables documenting non-existent cross-repo variants
- Update descriptions to accurately reflect command scope

## Test Plan

- Verify all internal markdown links are valid
- Confirm command references match files in agentsmd/commands/

🤖 Generated with [Claude Code](https://claude.com/claude-code)