### PR TITLE
feat: add missing command symlinks to .claude/commands

### DIFF
--- a/.claude/commands/fix-pr-ci.md
+++ b/.claude/commands/fix-pr-ci.md
@@ -1,0 +1,1 @@
+../../agentsmd/commands/fix-pr-ci.md

--- a/.claude/commands/rok-manage-pr.md
+++ b/.claude/commands/rok-manage-pr.md
@@ -1,0 +1,1 @@
+../../agentsmd/commands/rok-manage-pr.md

--- a/.claude/commands/sync-main-all.md
+++ b/.claude/commands/sync-main-all.md
@@ -1,0 +1,1 @@
+../../agentsmd/commands/sync-main-all.md

--- a/.claude/commands/sync-main.md
+++ b/.claude/commands/sync-main.md
@@ -1,0 +1,1 @@
+../../agentsmd/commands/sync-main.md

--- a/.claude/commands/sync-prs-with-main.md
+++ b/.claude/commands/sync-prs-with-main.md
@@ -1,0 +1,1 @@
+../../agentsmd/commands/sync-prs-with-main.md


### PR DESCRIPTION
## Summary

Add symlinks for commands that were in `agentsmd/commands/` but not exposed in `.claude/commands/`:

- `fix-pr-ci.md`
- `rok-manage-pr.md`  
- `sync-main.md`
- `sync-main-all.md`
- `sync-prs-with-main.md`

## Problem

These commands existed in `agentsmd/commands/` but weren't available as slash commands because they weren't symlinked to `.claude/commands/`.

## Solution

Added symlinks from `.claude/commands/` to `../../agentsmd/commands/` for each missing command.

## Test plan

- [ ] Verify symlinks are correct: `ls -la .claude/commands/ | grep sync`
- [ ] After merge, update flake input in nix-config and rebuild
- [ ] Verify `/sync-main` command is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)