### PR TITLE
fix: remove broken symlinks from refactoring

### DIFF
--- a/.claude/commands/rok-manage-pr.md
+++ b/.claude/commands/rok-manage-pr.md
@@ -1,1 +1,0 @@
-../../agentsmd/commands/rok-manage-pr.md

--- a/.claude/commands/sync-main-all.md
+++ b/.claude/commands/sync-main-all.md
@@ -1,1 +1,0 @@
-../../agentsmd/commands/sync-main-all.md

--- a/.claude/commands/sync-prs-with-main.md
+++ b/.claude/commands/sync-prs-with-main.md
@@ -1,1 +1,0 @@
-../../agentsmd/commands/sync-prs-with-main.md

--- a/.github/.copilot-pull-request-description-instructions.md
+++ b/.github/.copilot-pull-request-description-instructions.md
@@ -1,1 +1,0 @@
-../agentsmd/commands/pr.md


### PR DESCRIPTION
## Summary

Removes 4 broken symlinks that were left behind during the rok-prefix refactoring. These symlinks pointed to files that were removed and were causing the link-check CI to fail on every push to main.

## Files Removed

- `.github/.copilot-pull-request-description-instructions.md` -> ../agentsmd/commands/pr.md
- `.claude/commands/sync-main-all.md` -> ../../agentsmd/commands/sync-main-all.md
- `.claude/commands/sync-prs-with-main.md` -> ../../agentsmd/commands/sync-prs-with-main.md
- `.claude/commands/rok-manage-pr.md` -> ../../agentsmd/commands/rok-manage-pr.md

## Impact

- Fixes link-check CI failures on main
- No functional changes to the codebase