### PR TITLE
fix: correct relative path in SKILL.md

### DIFF
--- a/.claude/skills/github-graphql/SKILL.md
+++ b/.claude/skills/github-graphql/SKILL.md
@@ -231,7 +231,7 @@ All GraphQL operations must respect the **50-comment limit per PR** rule:
 
 1. Before posting new comments, check total comment count
 2. When limit is reached, resolve threads without posting new comments
-3. See [PR Comment Limits](../../agentsmd/rules/pr-comment-limits.md) for details
+3. See [PR Comment Limits](../../../agentsmd/rules/pr-comment-limits.md) for details
 
 ## Commands Using This Skill
 


### PR DESCRIPTION
## Summary
Fix broken link in `.claude/skills/github-graphql/SKILL.md` that was causing Link Check CI to fail.

## Changes
- Changed relative path from `../../agentsmd/rules/pr-comment-limits.md` to `../../../agentsmd/rules/pr-comment-limits.md`

## Root Cause
The file is located at `.claude/skills/github-graphql/SKILL.md`. The old path `../../` would resolve to `.claude/agentsmd/rules/...` which doesn't exist. The correct path needs `../../../` to reach the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)