### PR TITLE
fix: add missing symlink for ready-player-one command

### DIFF
--- a/.claude/commands/ready-player-one.md
+++ b/.claude/commands/ready-player-one.md
@@ -1,0 +1,1 @@
+../../agentsmd/commands/ready-player-one.md


### PR DESCRIPTION
## Summary

- Add missing symlink in `.claude/commands/` for `ready-player-one.md` command
- Ensures command is accessible from both `agentsmd/commands/` and `.claude/commands/` directories

## Root Cause

The `ready-player-one.md` command exists in `agentsmd/commands/` but was missing its corresponding symlink in `.claude/commands/`. All other command files have symlinks, making this an inconsistency.

## Changes

- Created symlink: `.claude/commands/ready-player-one.md` -> `../../agentsmd/commands/ready-player-one.md`

## Testing

- Verified symlink was created correctly
- Pre-commit hooks passed
- No other files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)