### PR TITLE
fix: remove unused variable in cleanup-stale-branches.sh

### DIFF
--- a/scripts/cleanup-stale-branches.sh
+++ b/scripts/cleanup-stale-branches.sh
@@ -125,7 +125,6 @@ get_merged_remote_branches() {
 # Main cleanup logic
 main() {
   local branches_to_delete=()
-  local branches_preserved=()
   local branches_with_open_prs=()
 
   echo "Analyzing branches for safe deletion..."


### PR DESCRIPTION
## Summary

- Remove unused local variable `branches_preserved` from `scripts/cleanup-stale-branches.sh`
- Resolves shellcheck SC2034 warning

## Root Cause

The variable `branches_preserved` was initialized on line 128 but never used anywhere in the script. This appears to be leftover code from a previous refactoring.

## Changes

**Before:**
```bash
main() {
  local branches_to_delete=()
  local branches_preserved=()
  local branches_with_open_prs=()
```

**After:**
```bash
main() {
  local branches_to_delete=()
  local branches_with_open_prs=()
```

## Verification

- Ran shellcheck on the modified file - no SC2034 warnings
- All pre-commit hooks passed
- No functional changes - purely code cleanup

## Shellcheck Output

**Before:** `SC2034 (warning): branches_preserved appears unused. Verify use (or export if used externally).`

**After:** No warnings

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)