### PR TITLE
fix: add timeout-minutes to lint workflows

### DIFF
--- a/.github/workflows/cclint.yml
+++ b/.github/workflows/cclint.yml
@@ -20,6 +20,7 @@ jobs:
   cclint:
     name: "Validate Claude Code Files"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -6,6 +6,7 @@ jobs:
   markdownlint-cli2:
     name: "Lint Markdown Files"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -10,6 +10,7 @@ jobs:
   spellcheck:
     name: "Check Spelling"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Add timeout-minutes: 5 configuration to three GitHub Actions workflows for consistency with other workflows in the repository.

## Changes
- Added timeout-minutes: 5 to cclint workflow
- Added timeout-minutes: 5 to markdownlint workflow  
- Added timeout-minutes: 5 to spellcheck workflow

This prevents workflows from running indefinitely and provides consistent timeout behavior across all lint-related CI jobs.