### PR TITLE
fix: increase issue-resolver max-turns from 2 to 4

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --max-turns 2
+            --max-turns 4
             --allowedTools "Bash(gh issue:*)"
 
           prompt: |


### PR DESCRIPTION
## Summary
- Increase max-turns from 2 to 4 in issue-resolver workflow

## Problem
The Issue Labeler workflow was consistently failing with `error_max_turns`. The workflow needs at least 3 turns to complete:
1. Read and analyze the issue
2. Determine appropriate labels
3. Execute the `gh issue edit` command

## Solution
Increased `--max-turns` from 2 to 4 to provide adequate headroom for the workflow to complete successfully.

## Test plan
- Workflow will be tested on next issue creation/edit
- Expected: Issue labeling completes without error_max_turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)