### PR TITLE
fix: restore Copilot PR description instructions symlink

### DIFF
--- a/.github/.copilot-pull-request-description-instructions.md
+++ b/.github/.copilot-pull-request-description-instructions.md
@@ -1,0 +1,1 @@
+../agentsmd/commands/manage-pr.md


### PR DESCRIPTION
## Summary

Recreates the `.github/.copilot-pull-request-description-instructions.md` symlink that was removed in PR #224. The symlink now points to `manage-pr.md` which contains comprehensive PR management instructions including PR description templates.

## Changes Made

- Created symlink: `.github/.copilot-pull-request-description-instructions.md` -> `../agentsmd/commands/manage-pr.md`
- Verified the symlink points to a valid file containing PR description guidance

## Why manage-pr.md?

The `manage-pr.md` file contains:
- PR description templates (lines 64-82)
- Complete PR workflow guidance
- Best practices for PR creation and management

This makes it the most appropriate target for Copilot's PR description generation assistance.

## Testing

- Verified symlink is valid: `test -f .github/.copilot-pull-request-description-instructions.md`
- Confirmed target file exists: `agentsmd/commands/manage-pr.md`
- Pre-commit hooks passed

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)