### PR TITLE
fix: remove broken symlinks

### DIFF
--- a/.github/.copilot-codeGeneration-instructions.md
+++ b/.github/.copilot-codeGeneration-instructions.md
@@ -1,1 +1,0 @@
-../agentsmd/commands/generate-code.md

--- a/.github/prompts/generate-code.prompt.md
+++ b/.github/prompts/generate-code.prompt.md
@@ -1,1 +1,0 @@
-../../agentsmd/commands/generate-code.md

--- a/.github/prompts/infrastructure-review.prompt.md
+++ b/.github/prompts/infrastructure-review.prompt.md
@@ -1,1 +1,0 @@
-../../agentsmd/commands/infrastructure-review.md


### PR DESCRIPTION
## Summary
Remove broken symlinks that were causing link validation CI checks to fail.

These symlinks pointed to non-existent command definition files and have been deleted:
- `.github/.copilot-codeGeneration-instructions.md`
- `.github/prompts/generate-code.prompt.md`
- `.github/prompts/infrastructure-review.prompt.md`

## Test Plan
- Verify link validation CI check passes
- Confirm no broken symlinks remain in repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)