### PR TITLE
fix: resolve Claude Code schema validation errors in permissions

### DIFF
--- a/.claude/permissions/allow.json
+++ b/.claude/permissions/allow.json
@@ -1,12 +1,6 @@
 {
   "permissions": [
-    "Read(**)",
-    "Glob(**)",
-    "Grep(**)",
-    "WebSearch",
-    "TodoWrite",
-    "TodoRead",
-    "SlashCommand(**)",
+    "SlashCommand(/:*)",
 
     "Bash(git status:*)",
     "Bash(git log:*)",
@@ -343,7 +337,7 @@
     "Bash(darwin-rebuild --list-generations:*)",
     "Bash(darwin-rebuild --rollback:*)",
     "Bash(sudo darwin-rebuild:*)",
-    "Read(//nix/store/**)",
+    "Read(/nix/store/**)",
 
     "Bash(direnv status:*)",
     "Bash(direnv reload:*)",

--- a/.claude/permissions/modules/core.json
+++ b/.claude/permissions/modules/core.json
@@ -1,12 +1,6 @@
 {
   "permissions": [
-    "Read(**)",
-    "Glob(**)",
-    "Grep(**)",
-    "WebSearch",
-    "TodoWrite",
-    "TodoRead",
-    "SlashCommand(**)",
+    "SlashCommand(/:*)",
 
     "Bash(git status:*)",
     "Bash(git log:*)",

--- a/.claude/permissions/modules/nix.json
+++ b/.claude/permissions/modules/nix.json
@@ -40,7 +40,7 @@
     "Bash(darwin-rebuild --list-generations:*)",
     "Bash(darwin-rebuild --rollback:*)",
     "Bash(sudo darwin-rebuild:*)",
-    "Read(//nix/store/**)",
+    "Read(/nix/store/**)",
     "Bash(nixfmt-rfc-style --version:*)",
     "Bash(nixfmt:*)",
     "Bash(nix fmt:*)",


### PR DESCRIPTION
## Summary

Fixes Claude Code schema validation errors in permission configuration files.

## Changes

- **Removed built-in tool permissions**: `Read(**)`, `Glob(**)`, `Grep(**)`, `WebSearch`, `TodoWrite`, `TodoRead` - these are now handled by built-in defaults
- **Fixed SlashCommand pattern**: Changed `SlashCommand(**)` → `SlashCommand(/:*)` to satisfy schema requirement for non-wildcard characters
- **Fixed path syntax**: Corrected `Read(//nix/store/**)` → `Read(/nix/store/**)`

## Validation Errors Resolved

```
$.permissions.allow[0]: 'Read(**)' does not match pattern
$.permissions.allow[1]: 'Glob(**)' does not match pattern
$.permissions.allow[2]: 'Grep(**)' does not match pattern
$.permissions.allow[5]: 'TodoRead' does not match pattern
$.permissions.allow[6]: 'SlashCommand(**)' does not match pattern
```

The schema requires permission patterns to contain at least one non-wildcard character inside parentheses (enforced by regex lookahead `(?=.*[^)*?])`).

## Files Modified

- `.claude/permissions/allow.json` (legacy file being phased out)
- `.claude/permissions/modules/core.json` (source of truth)
- `.claude/permissions/modules/nix.json`

## Test plan

- [x] Verify schema validation passes
- [x] Confirm SlashCommand pattern matches all slash commands
- [x] Check no functionality regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)