### PR TITLE
feat: add 'defaults read' to system command permissions

### DIFF
--- a/agentsmd/permissions/allow/system.json
+++ b/agentsmd/permissions/allow/system.json
@@ -61,6 +61,7 @@
     "ps",
     "top -l 1",
     "df",
+    "defaults read",
     "du",
     "free",
     "launchctl list",


### PR DESCRIPTION
Adds 'defaults read' to the always-allowed permissions list in agentsmd/permissions/allow/system.json.

This enables scripts and workflows to query macOS user defaults without requiring explicit permission checks.

Fixes #363
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `defaults read` to always-allowed permissions in `system.json` for querying macOS user defaults.
> 
>   - **Permissions**:
>     - Add `defaults read` to `agentsmd/permissions/allow/system.json` to allow querying macOS user defaults without explicit permission checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for 3b7ca6fee5bfa4419828de1429541c5d83624464. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->