### PR TITLE
docs: clarify folder naming independence for git-rebase and init-worktree

### DIFF
--- a/agentsmd/commands/git-rebase.md
+++ b/agentsmd/commands/git-rebase.md
@@ -21,6 +21,9 @@ feature-branch ──rebase──> main ──push──> origin/main → PR aut
 2. No ambiguous refs: `git show-ref origin/main` (1 line only)
 3. Discover paths via `git worktree list` (use the worktree-management skill)
 
+**Note**: This command works regardless of local folder naming. Paths are discovered via `git worktree list`,
+and remote operations use git metadata (origin URL), not directory names.
+
 ## Four Steps
 
 ```bash

--- a/agentsmd/commands/init-worktree.md
+++ b/agentsmd/commands/init-worktree.md
@@ -54,6 +54,9 @@ See the worktree-management skill for main branch synchronization and merging pa
 
 Examples: "add dark mode" → `feat/add-dark-mode`, "fix login bug" → `fix/login-bug`
 
+**Note on folder naming**: The `<repo-name>` folder can be any name (e.g., `my-custom-folder`). Subsequent
+commands like `/git-rebase` use git metadata (remote URL) and `git worktree list`, not directory names.
+
 See the worktree-management skill for branch naming conventions and worktree path structure.
 
 ### 6. Create Worktree


### PR DESCRIPTION
Updates documentation in both git-rebase.md and init-worktree.md to clarify that these commands work with any folder naming.

Changes:
- git-rebase.md: Added note that command works regardless of folder naming
- init-worktree.md: Added note that folder can be any custom name and subsequent commands use git metadata

The commands use git metadata (remote URL) and 'git worktree list' for operations, not directory names, so folder naming is flexible.

Fixes #374
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies in documentation that `git-rebase` and `init-worktree` commands are independent of folder naming, using git metadata.
> 
>   - **Documentation**:
>     - `git-rebase.md`: Added note clarifying command works regardless of local folder naming, using `git worktree list` and git metadata.
>     - `init-worktree.md`: Added note that `<repo-name>` folder can be any name, as commands use git metadata and `git worktree list`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for 28adbbbb6eb7b5663d92c597494585ae9c77b136. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->