### PR TITLE
fix: add rm command to system allow list

### DIFF
--- a/agentsmd/permissions/allow/system.json
+++ b/agentsmd/permissions/allow/system.json
@@ -12,6 +12,7 @@
     "tree",
     "pwd",
     "cd",
+    "rm",
     "diff",
     "cut",
     "sort",


### PR DESCRIPTION
Adds rm to the always-allowed system commands in agentsmd/permissions/allow/system.json.

This enables scripts like sync-permissions to clean up configuration files safely.

Fixes #338
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `rm` to the allowed system commands in `system.json` to enable safe cleanup by scripts like `sync-permissions`.
> 
>   - **Behavior**:
>     - Adds `rm` to the always-allowed system commands in `system.json` to enable scripts like `sync-permissions` to clean up configuration files.
>   - **Fixes**:
>     - Resolves issue #338.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for 53206cb1b5907308647e7535b8ea11efb7a91801. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->