### PR TITLE
fix: add shell tools to system allow list

### DIFF
--- a/agentsmd/permissions/allow/system.json
+++ b/agentsmd/permissions/allow/system.json
@@ -1,5 +1,7 @@
 {
   "commands": [
+    "awk",
+    "basename",
     "ls",
     "cat",
     "head",
@@ -15,6 +17,7 @@
     "diff",
     "cut",
     "sort",
+    "tr",
     "uniq",
     "jq",
     "yq",


### PR DESCRIPTION
Adds awk, basename, and tr to agentsmd/permissions/allow/system.json for script and agent usage.

Fixes #337
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `awk`, `basename`, and `tr` to `system.json` allow list for script and agent usage, fixing issue #337.
> 
>   - **Behavior**:
>     - Adds `awk`, `basename`, and `tr` to `commands` in `system.json` for script and agent usage.
>   - **Issue Fix**:
>     - Fixes issue #337 by expanding the allow list to include necessary shell tools.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for 30577951abd83f9d052baa80ec615afa92166efa. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->