### PR TITLE
docs: fix markdownlint config filename in documentation

### DIFF
--- a/agentsmd/agents/linter-fixer.md
+++ b/agentsmd/agents/linter-fixer.md
@@ -530,7 +530,7 @@ Or run: npx eslint --init
 - Excellent auto-fix support for formatting
 - Can fix heading styles, list indentation, trailing spaces
 - Cannot fix content issues (broken links, spelling)
-- Uses .markdownlint.json configuration
+- Uses .markdownlint-cli2.jsonc configuration
 
 ### Ruff (Python)
 

--- a/agentsmd/commands/review-docs.md
+++ b/agentsmd/commands/review-docs.md
@@ -38,7 +38,7 @@ Review the project's documentation files (`.md`) for consistency, completeness, 
       * Never break words mid-character or split natural phrases
     * All other markdownlint rules must pass
     * Fix existing violations before creating pull requests
-    * Configuration in `.markdownlint.json` sets MD013 to 160 characters
+    * Configuration in `.markdownlint-cli2.jsonc` sets MD013 to 160 characters
 
 4. **Content Quality Verification**:
     * Is the documentation accurate and up-to-date with the current codebase?

--- a/agentsmd/rules/documentation-standards.md
+++ b/agentsmd/rules/documentation-standards.md
@@ -25,7 +25,7 @@ This is enforced automatically before each commit using `pre-commit`.
 ### Pre-commit Hook
 
 The project includes a `.pre-commit-config.yaml` file that configures `markdownlint-cli2` to run on all `.md` files.
-This ensures that any file that violates the rules defined in `.markdownlint.json` cannot be committed.
+This ensures that any file that violates the rules defined in `.markdownlint-cli2.jsonc` cannot be committed.
 
 ### Local Setup
 


### PR DESCRIPTION
Updates 3 documentation files to use correct markdownlint config filename:
- agentsmd/agents/linter-fixer.md
- agentsmd/rules/documentation-standards.md  
- agentsmd/commands/review-docs.md

Fixes #314
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update markdownlint config filename in documentation to `.markdownlint-cli2.jsonc`.
> 
>   - **Documentation**:
>     - Updates markdownlint config filename from `.markdownlint.json` to `.markdownlint-cli2.jsonc` in `agents/linter-fixer.md`, `commands/review-docs.md`, and `rules/documentation-standards.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for d29da57c5e2949f4291d508b73a736aba2cc098a. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->