### PR TITLE
docs: update review-pr command to use npm instead of bun

### DIFF
--- a/agentsmd/commands/review-pr.md
+++ b/agentsmd/commands/review-pr.md
@@ -37,7 +37,8 @@ See the github-cli-patterns skill for:
 - **Review Submission**: `gh pr review --approve`, `--request-changes`
 - **Line Comments**: via gh API
 
-For local quality checks: `bun run typecheck && bun run test:run && bun run build && bun run lint`
+For local quality checks: `npm run typecheck && npm run test && npm run build && npm run lint`
+(Adjust to match your project's package manager scripts if using yarn, pnpm, or bun)
 
 ### Review Workflow
 


### PR DESCRIPTION
## Summary

Update review-pr command documentation to use npm instead of bun, making it compatible with projects using npm, yarn, pnpm, or bun.

## Changes

- **Before**: Hardcoded `bun run` commands
- **After**: Uses `npm run` as default with note about adjusting for other package managers

## Commands Updated

```diff
- bun run typecheck && bun run test:run && bun run build && bun run lint
+ npm run typecheck && npm run test && npm run build && npm run lint
+ (Adjust to match your project's package manager scripts if using yarn, pnpm, or bun)
```

## Rationale

The allowed-tools declaration in the command includes `Bash(npm:*)`, indicating npm is the primary package manager. Using npm as the default makes the command more broadly applicable while still being clear that users should adjust for their package manager.

Fixes #320

🤖 Generated with Claude Code

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `review-pr` command documentation to use `npm` instead of `bun` for broader compatibility.
> 
>   - **Documentation Update**:
>     - Changes `review-pr` command documentation in `review-pr.md` to use `npm run` instead of `bun run` for local quality checks.
>     - Adds note to adjust commands for other package managers like yarn, pnpm, or bun.
>   - **Rationale**:
>     - Aligns with `allowed-tools` declaration indicating `npm` as the primary package manager.
>     - Makes the command more broadly applicable across different projects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for 4c59faf30f5cea5f3735f8e075db346986a29e5b. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->