### PR TITLE
fix: remove duplicate permissions (basename, tr)

### DIFF
--- a/agentsmd/permissions/allow/system.json
+++ b/agentsmd/permissions/allow/system.json
@@ -1,6 +1,5 @@
 {
   "commands": [
-    "basename",
     "defaults read",
     "htop",
     "launchctl list",
@@ -22,7 +21,6 @@
     "tar -tzf",
     "tar -xzf",
     "tldr",
-    "top -l 1",
-    "tr"
+    "top -l 1"
   ]
 }


### PR DESCRIPTION
These commands were defined in both core.json and system.json,
causing "non-unique elements" validation warnings in Claude Code.

Removed from system.json since they're already covered by core.json.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove duplicate commands from `system.json` and add duplicate command check in `validate-permissions.sh`.
> 
>   - **Permissions**:
>     - Remove duplicate commands `basename` and `tr` from `system.json`.
>   - **Validation**:
>     - Add `check_all_duplicates()` function in `validate-permissions.sh` to log errors for duplicate commands across `allow/`, `ask/`, and `deny/` directories.
>     - Integrate duplicate check into `main()` function in `validate-permissions.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for bb8a90b95939f7d460e76be7d76ab8150eaaf638. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->