### PR TITLE
chore: remove agent-os references

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -165,7 +165,6 @@
   ],
   "ignorePaths": [
     ".git",
-    "agent-os",
     "node_modules"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 todos/
 result
 
-agent-os
-
 # Use docs/ instead of these legacy folders
 .specs/
 .tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,7 @@ When choosing implementations or tools:
 
 1. **Anthropic Official** - Claude Code plugins, skills, patterns
 2. **PAL MCP** - Multi-model orchestration tools
-3. **Agent OS** - Structured development workflows
-4. **Personal/Custom** - Only when no alternative exists
+3. **Personal/Custom** - Only when no alternative exists
 
 ## Local-Only Mode
 


### PR DESCRIPTION
## Summary

- Remove Agent OS from Priority Order in CLAUDE.md/AGENTS.md
- Remove agent-os from .cspell.json ignorePaths
- Remove agent-os from .gitignore

Agent OS v3 has deprecated its core functionality. Frontier AI models now handle what Agent OS previously provided.

## Migration Reference

https://buildermethods.com/agent-os/migration

## Test plan

- [ ] Verify no remaining agent-os references with `grep -r "agent-os" .`
- [ ] Confirm cspell and markdownlint still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `agent-os` references from `AGENTS.md`, `.cspell.json`, and `.gitignore`.
> 
>   - **Behavior**:
>     - Remove `Agent OS` from priority order in `AGENTS.md`.
>     - Remove `agent-os` from `ignorePaths` in `.cspell.json` and `.gitignore`.
>   - **Misc**:
>     - `Agent OS` functionality is now handled by Frontier AI models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for da635533024a7182884b5269984ffd98d16e032e. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->