### PR TITLE
feat(init-worktree): symlink .docs/ from repo root into worktrees

### DIFF
--- a/agentsmd/commands/init-worktree.md
+++ b/agentsmd/commands/init-worktree.md
@@ -65,6 +65,10 @@ If `.docs/` exists at repo root, symlink it into the worktree for project-specif
 ```bash
 # Check if .docs/ exists at repo root
 if [ -d ~/git/<repo-name>/.docs ]; then
+  # Remove any existing .docs in the worktree to ensure idempotency
+  if [ -e ~/git/<repo-name>/<branch-name>/.docs ]; then
+    rm -rf ~/git/<repo-name>/<branch-name>/.docs
+  fi
   ln -s ~/git/<repo-name>/.docs ~/git/<repo-name>/<branch-name>/.docs
 fi
 ```


### PR DESCRIPTION
## Summary

- Adds step 7 to `/init-worktree` command that symlinks the `.docs/` folder (if it exists at repo root) into newly created worktrees
- Updates allowed-tools to include `ln -s` and `test` commands
- Updates step 8 (Verify and Report) to mention whether `.docs/` was symlinked

## Problem

When working in worktrees, project-specific documentation in `.docs/` at the repo root was not accessible. This caused issues where:
- Infrastructure command patterns (like `doppler run -- ansible-playbook`) weren't visible
- Connection details and secrets patterns weren't available
- Developers had to manually navigate to repo root to find instructions

## Solution

Automatically symlink `.docs/` into each worktree during `/init-worktree`, making project-specific documentation accessible everywhere.

## Test plan

- [x] Pre-commit hooks pass (markdownlint, cspell, etc.)
- [ ] Verify symlink created when `.docs/` exists at repo root
- [ ] Verify no error when `.docs/` doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds symlink of `.docs/` into worktrees in `/init-worktree` and updates allowed tools.
> 
>   - **Behavior**:
>     - Adds step 7 to `/init-worktree` to symlink `.docs/` from repo root into worktrees if it exists.
>     - Updates step 8 to report whether `.docs/` was symlinked.
>   - **Tools**:
>     - Updates allowed-tools to include `ln -s` and `test` commands in `init-worktree.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for ee68b55a4fcad7337aaf987f35589639f48aa958. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->