### PR TITLE
docs: add portable path guidance to prevent user-specific paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ When `localOnlyMode` is enabled or `--local` flag is passed:
 ❌ Database credentials
 ❌ AWS account IDs, ARNs, or API keys
 ❌ Encryption keys or secrets
-❌ **User-specific absolute paths**: `/Users/{username}/*`, `/home/{username}/*`, `$HOME/*`, `~/*` in git-tracked files
+❌ User-specific absolute paths
 
 ### Scrubbed Values for Git-Committed Files
 
@@ -127,14 +127,14 @@ Use these placeholders consistently across all repositories:
 
 ### Portable Path References
 
-**NEVER commit absolute user paths in git-tracked files.** Use these alternatives:
+**NEVER commit absolute user paths in git-tracked files.** This includes `/Users/{username}/*`, `/home/{username}/*`, `$HOME/*`, and `~/*` patterns. Use these alternatives:
 
 | Bad (User-Specific) | Good (Portable) | Use Case |
 | --- | --- | --- |
 | `/Users/john/.local/bin/tool` | `tool` | Use PATH lookup for system commands |
 | `entry: /Users/john/.local/bin/ansible-lint` | `entry: ansible-lint` | Pre-commit hooks, scripts |
-| `~/.ssh/id_rsa` | Comment with placeholder | Example files, templates |
-| `$HOME/git/nix-config/main` | `${NIX_SHELL}` (env var) | Configurable paths in scripts |
+| `~/.ssh/id_rsa` | Placeholder comment (e.g., `# /path/to/your/ssh/key`) | Example files, templates |
+| `$HOME/git/nix-config/main` | `${NIX_CONFIG_PATH}/main` (env var) | Configurable paths in scripts |
 | `/home/user/project/file.txt` | `./file.txt` or `../file.txt` | Relative paths within project |
 
 **When to use environment variables:**


### PR DESCRIPTION
## Summary

Add comprehensive guidance on avoiding hardcoded user paths in git-tracked files.

## Changes

- Added to "What NOT to Commit" list: user-specific absolute paths (`/Users/{username}`, `$HOME`, `~`)
- New "Portable Path References" section with practical examples
- Covers alternatives: PATH lookup, environment variables, relative paths, placeholders
- Provides bad vs. good pattern examples for common scenarios

## Motivation

This prevents portability issues where paths like `/Users/jevans/.local/bin/ansible-lint` or `~/.ssh/id_rsa` are committed to repositories. These hardcoded paths break on other developers' machines and CI environments.

Triggered by review feedback on ansible-proxmox#42 where multiple hardcoded user paths were identified.

## Test Plan

- [x] Pre-commit hooks pass
- [x] Documentation is clear and actionable
- [x] Examples cover common use cases (pre-commit, scripts, examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds guidance in `AGENTS.md` to avoid user-specific paths in git-tracked files, promoting portability.
> 
>   - **Documentation**:
>     - Adds user-specific absolute paths to "What NOT to Commit" list in `AGENTS.md`.
>     - Introduces "Portable Path References" section in `AGENTS.md` with examples and alternatives.
>     - Provides examples of bad vs. good patterns for path references.
>   - **Guidance**:
>     - Recommends using PATH lookup, environment variables, relative paths, and placeholders instead of hardcoded paths.
>     - Offers specific scenarios for when to use environment variables, relative paths, and placeholders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for dae0129ac5e70a81287accc273eee65e7031f87f. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->