### PR TITLE
feat(renovate): extend shared preset for org-wide auto-merge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ],
-  "packageRules": [
-    {
-      "description": "Auto-merge official GitHub Actions (including major versions)",
-      "matchDatasources": ["github-actions"],
-      "matchPackagePrefixes": ["actions/"],
-      "automerge": true,
-      "automergeType": "squash",
-      "minimumReleaseAge": null
-    }
+    "config:recommended",
+    "local>JacobPEvans/.github:renovate-presets"
   ]
 }


### PR DESCRIPTION
## Summary

- Extends `local>JacobPEvans/.github:renovate-presets` to inherit org-wide auto-merge rules
- Removes local `actions/` auto-merge rule now covered by shared preset
- Trusted publishers (JacobPEvans/, actions/, googleapis/, anthropics/) and pre-commit hooks now auto-merge via shared preset

## Why

Centralizes Renovate auto-merge configuration in the `.github` repo preset, eliminating duplication across repos.

## Test plan

- [ ] Merge `.github` PR #69 first (preset must be on main before Renovate runs)
- [ ] Verify next Renovate PR gets auto-merge enabled at creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extends `renovate.json` to use shared preset for org-wide auto-merge rules, removing redundant local rule.
> 
>   - **Configuration**:
>     - Extends `renovate.json` to include `local>JacobPEvans/.github:renovate-presets` for org-wide auto-merge rules.
>     - Removes local `actions/` auto-merge rule, now covered by shared preset.
>   - **Behavior**:
>     - Trusted publishers (`JacobPEvans/`, `actions/`, `googleapis/`, `anthropics/`) and pre-commit hooks auto-merge via shared preset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for 8f351e3aae2fac18db473caabc8be55f52b9e217. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->