### PR TITLE
feat: expand shell deny rules + add ecosystem-first guidance

### DIFF
--- a/agentsmd/permissions/deny/shell.json
+++ b/agentsmd/permissions/deny/shell.json
@@ -1,13 +1,26 @@
 {
   "commands": [
     "cat > /tmp/",
+    "cat >> /tmp/",
+    "tee /tmp/",
     "python3 <<",
     "python3 -c",
+    "python3 -",
     "python3 /dev/",
     "python3 /tmp/",
     "python <<",
     "python -c",
+    "python -",
     "python /dev/",
-    "python /tmp/"
+    "python /tmp/",
+    "bash -c",
+    "sh -c",
+    "zsh -c",
+    "node -e",
+    "node --eval",
+    "ruby -e",
+    "ruby --eval",
+    "perl -e",
+    "perl -c"
   ]
 }

--- a/agentsmd/rules/ai-tooling.md
+++ b/agentsmd/rules/ai-tooling.md
@@ -43,6 +43,15 @@ See [Gemini CLI Configuration](https://geminicli.com/docs/get-started/configurat
 
 Always prefer using allowed commands to maintain automation flow without interrupting the user for confirmation.
 
+### Prefer Ecosystem Tools Over Custom Code
+
+Before any data processing, config generation, or automation task:
+
+1. **Research what exists** — use Context7 MCP, PAL MCP, and web search to verify current capabilities
+2. **Check ecosystem built-ins** — Nix, Terraform, Ansible, GitHub Actions all have extensive native functionality
+3. **Use existing CLI tools** — `jq`, `yq`, `gh`, `curl`, `nix eval` handle most tasks
+4. **Run commands directly** — the Bash tool is the execution layer, not a script-writing tool
+
 ### Handling Blocked Commands
 
 If a command is blocked or requires confirmation:


### PR DESCRIPTION
## Summary

- Expand `agentsmd/permissions/deny/shell.json` from 9 → 22 rules: add `tee /tmp/`, `bash/sh/zsh -c`, `node -e/--eval`, `ruby -e/--eval`, `perl -e/c`, `python3 -/dev/tmp` variants
- Add "Prefer Ecosystem Tools Over Custom Code" section to `agentsmd/rules/ai-tooling.md` with 4-step research-first workflow

## Motivation

Hard enforcement layer for the script-creation anti-pattern. Deny rules make the wrong path impossible while the updated instructions define the happy path.

## Test plan

- [ ] Run `/sync-permissions` after merge to propagate rules to `~/.claude/settings.json`
- [ ] Verify `validate-permissions` CI check passes
- [ ] Verify markdownlint passes on ai-tooling.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expand shell deny rules in `shell.json` and add ecosystem-first guidance in `ai-tooling.md`.
> 
>   - **Permissions**:
>     - Expand `agentsmd/permissions/deny/shell.json` from 9 to 22 rules, adding `tee /tmp/`, `bash/sh/zsh -c`, `node -e/--eval`, `ruby -e/--eval`, `perl -e/c`, `python3 -/dev/tmp` variants.
>   - **Documentation**:
>     - Add "Prefer Ecosystem Tools Over Custom Code" section to `agentsmd/rules/ai-tooling.md` with a 4-step research-first workflow.
>   - **Testing**:
>     - Instructions to run `/sync-permissions` after merge to update `~/.claude/settings.json`.
>     - Verify `validate-permissions` CI check and markdownlint on `ai-tooling.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for e14deaf4439bf894ea6fe8e72dc36dca00fc8dbb. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->