### PR TITLE
feat(renovate): extend shared preset for org-wide auto-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ],
-  "packageRules": [
-    {
-      "description": "Auto-merge official GitHub Actions (including major versions)",
-      "matchDatasources": ["github-actions"],
-      "matchPackagePrefixes": ["actions/"],
-      "automerge": true,
-      "automergeType": "squash",
-      "minimumReleaseAge": null
-    }
+    "config:recommended",
+    "local>JacobPEvans/.github:renovate-presets"
   ]
 }


### PR DESCRIPTION
## Summary
- Add local>JacobPEvans/.github:renovate-presets to extends array
- Rules for trusted publishers (actions/, googleapis/, anthropics/, JacobPEvans/) and pre-commit now inherited from shared preset
- Remove local actions/ auto-merge packageRule now covered by shared preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extends shared preset in `renovate.json` for org-wide auto-merge, removing local GitHub Actions rule.
> 
>   - **Configuration**:
>     - Extends `local>JacobPEvans/.github:renovate-presets` in `renovate.json` for org-wide auto-merge rules.
>     - Removes local `packageRule` for auto-merging GitHub Actions, now covered by shared preset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-assistant-instructions&utm_source=github&utm_medium=referral)<sup> for 8f351e3aae2fac18db473caabc8be55f52b9e217. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->