### PR TITLE
docs: note Gemini thinking-model reasoning-token trap (all current models)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,21 +145,14 @@ This is about output format, not thinking. Reason thoroughly. Write concisely.
 Default local model: `mlx-community/Qwen3.5-27B-4bit` (always loaded).
 Larger models are on-demand via `mlx-switch`. Run `listmodels` for available models and aliases.
 
-### Provider gotchas
+### Provider Gotchas
 
-- **Gemini thinking models — reasoning tokens count against `max_tokens`.**
-  All current Gemini thinking models (including `gemini-3-pro-preview` and the
-  current flash variants) consume internal reasoning tokens **before** emitting
-  the user-facing answer, and those reasoning tokens are billed against the
-  `max_tokens` budget on the OpenAI-compatible API. If `max_tokens` is too
-  small, the model can burn the entire budget on reasoning and return
-  `choices: null` with `completion_tokens_details.reasoning_tokens` matching
-  `completion_tokens`. **Always set `max_tokens >= 100`** for any Gemini
-  thinking-model call via the OpenAI-compatible API; budget
-  ~30 tokens for reasoning overhead plus your expected answer length. This
-  affects every OpenAI-compatible client (direct or through Bifrost), not
-  just one model version — the behavior is a Gemini API surface standard for
-  thinking models.
+- **Gemini thinking-model reasoning tokens.** **Set `max_tokens >= 100`** for
+  any Gemini thinking-model call via the OpenAI-compatible API. Reasoning
+  tokens count against the `max_tokens` budget before the answer is emitted —
+  with too small a limit, ~30 % of requests return `choices: null`. Budget
+  ~30 tokens for reasoning overhead plus expected answer length. Applies
+  to every OpenAI-compatible client (direct or through Bifrost).
 
 ## PAL MCP Tools
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,22 @@ This is about output format, not thinking. Reason thoroughly. Write concisely.
 Default local model: `mlx-community/Qwen3.5-27B-4bit` (always loaded).
 Larger models are on-demand via `mlx-switch`. Run `listmodels` for available models and aliases.
 
+### Provider gotchas
+
+- **Gemini thinking models — reasoning tokens count against `max_tokens`.**
+  All current Gemini thinking models (including `gemini-3-pro-preview` and the
+  current flash variants) consume internal reasoning tokens **before** emitting
+  the user-facing answer, and those reasoning tokens are billed against the
+  `max_tokens` budget on the OpenAI-compatible API. If `max_tokens` is too
+  small, the model can burn the entire budget on reasoning and return
+  `choices: null` with `completion_tokens_details.reasoning_tokens` matching
+  `completion_tokens`. **Always set `max_tokens >= 100`** for any Gemini
+  thinking-model call via the OpenAI-compatible API; budget
+  ~30 tokens for reasoning overhead plus your expected answer length. This
+  affects every OpenAI-compatible client (direct or through Bifrost), not
+  just one model version — the behavior is a Gemini API surface standard for
+  thinking models.
+
 ## PAL MCP Tools
 
 | Tool | Purpose |


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450

## Summary

Adds a "Provider gotchas" subsection under Model Routing Rules in `AGENTS.md` documenting the reasoning-token behavior shared by all current Gemini thinking models (`gemini-3-pro-preview` and current flash variants).

## Why

All current Gemini thinking models consume **reasoning tokens** before emitting the user-facing answer, and those tokens are billed against the `max_tokens` budget on the OpenAI-compatible API. If `max_tokens` is too small, the model can burn the entire allowance on internal reasoning and return `choices: null`, with the `usage.completion_tokens_details.reasoning_tokens` field matching `completion_tokens` (meaning every generated token was a reasoning token and none were available for the answer).

This affects **every** OpenAI-compatible client — direct Gemini API calls, Bifrost, Vertex AI compatibility shims, etc. It's a Gemini API surface standard for thinking models, not a bug in any specific client or gateway.

## Fix guidance

- **Always set `max_tokens >= 100`** for any Gemini thinking-model call via the OpenAI-compatible API
- Rule of thumb: budget ~30 tokens for reasoning overhead + expected answer length
- For a yes/no answer, `max_tokens=50` is the practical floor; for a paragraph, `max_tokens=500`

## Model-version notes

Written generically rather than naming specific model versions. Model identifiers churn (new releases, deprecations, etc.) and the underlying reasoning-token behavior is stable across thinking-model variants, so the guidance is expressed in terms of API surface rather than a specific model string. Consumers should reference the Model Routing Rules table above for the currently-supported Gemini model identifiers.

## Scope

Pure docs change. One 16-line subsection added to `AGENTS.md` right after the Model Routing Rules table and before the PAL MCP Tools section. `CLAUDE.md` and `GEMINI.md` are symlinks so this change propagates automatically to all three canonical AI-instruction entry points.

## Test plan

- [x] Pre-commit passes locally (markdownlint, cspell, lychee, link check)
- [ ] CI passes
