### PR TITLE
feat(rules): add nix-package-placement decision matrix

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -193,7 +193,10 @@
     "unauditable",
     "vllm",
     "plist",
-    "plists"
+    "plists",
+    "mactop",
+    "portaudio",
+    "pyright"
   ],
   "files": [
     "**/*.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,7 @@ path-scoped rules lazy-load only when matching files enter context.
 **Path-scoped (lazy-load on matching files):**
 
 - `nix-tool-policy.md` — Nix dev shell rules (flake.nix, *.nix, .envrc)
+- `nix-package-placement.md` — Where tools belong across the nix quartet (*.nix, flake.*)
 - `ci-cd-policy.md` — CI/CD automation rules (.github/**, scripts/**, hooks/**)
 - `config-secrets.md` — Secret scrubbing details (.env*,*.json, *.yaml,*.tf)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ path-scoped rules lazy-load only when matching files enter context.
 **Path-scoped (lazy-load on matching files):**
 
 - `nix-tool-policy.md` — Nix dev shell rules (flake.nix, *.nix, .envrc)
-- `nix-package-placement.md` — Where tools belong across the nix quartet (*.nix, flake.*)
+- `nix-package-placement.md` — Where tools belong across the nix repos (*.nix, flake.*)
 - `ci-cd-policy.md` — CI/CD automation rules (.github/**, scripts/**, hooks/**)
 - `config-secrets.md` — Secret scrubbing details (.env*,*.json, *.yaml,*.tf)
 

--- a/agentsmd/rules/nix-package-placement.md
+++ b/agentsmd/rules/nix-package-placement.md
@@ -1,0 +1,71 @@
+---
+description: Package placement decision matrix for the nix-darwin / nix-ai / nix-home / nix-devenv quartet — where tools belong and when to use nix run instead
+paths:
+  - "**/*.nix"
+  - "flake.nix"
+  - "flake.lock"
+---
+
+# Nix Package Placement
+
+Three tiers. Place a tool in the lowest tier that satisfies all its requirements.
+
+## Placement Decision Matrix
+
+| Package category | Correct home | Mechanism |
+| --- | --- | --- |
+| Core bootstrapping (git, gnupg, vim) | **nix-darwin** | `environment.systemPackages` |
+| macOS-only system tools (mas, mactop) | **nix-darwin** | `environment.systemPackages` |
+| macOS system-level C libs (sox, portaudio) | **nix-darwin** | `environment.systemPackages` |
+| GUI apps unavailable in nixpkgs | **nix-darwin** | `homebrew.casks` |
+| CLI tools unavailable in nixpkgs or version-pinned | **nix-darwin** | `homebrew.brews` |
+| AI tools, MCP servers, speech/audio stack | **nix-ai** | `home.packages` |
+| User dev tools, shell config, linters, credentials | **nix-home** | `home.packages` |
+| Pre-commit hook tools (must be on PATH globally) | **nix-home** | `home.packages` |
+| Project-specific toolchains | **nix-devenv** | importable module |
+| Language-specific testers, CI linters (bats, actionlint) | **nix-devenv** | shell `buildInputs` |
+| Occasional one-off tools (diagramming, previews) | ephemeral | `nix run nixpkgs#<pkg>` |
+| npm-backed CLI tools | ephemeral | `bunx <pkg>@version` |
+| Python CLI tools | ephemeral | `uvx <pkg>` |
+
+## Critical Rules
+
+**homebrew.brews stays in nix-darwin.** Home-manager (`nix-ai`, `nix-home`) cannot declare
+Homebrew formulas — `homebrew.*` is a nix-darwin option only. Group AI-adjacent brew tools
+with a `# AI tools` comment block for logical clarity, not a repo move.
+
+**Pre-commit hooks with `language: system`** require the tool on PATH. If a tool is used
+as a `language: system` pre-commit hook, it must stay in `nix-home` home.packages even if
+it feels project-specific (e.g., `lychee`).
+
+**IDE linters stay global.** Tools like `pyright` that IDEs invoke as background processes
+must be in `home.packages` (always on PATH). Moving them to a project devenv shell breaks
+editor integration because IDEs activate the system environment, not a project shell.
+
+## On-Demand Patterns
+
+```bash
+# Zero-install ephemeral runs (like bunx but for Nix):
+nix run nixpkgs#d2 -- input.d2 output.svg
+nix run nixpkgs#nodePackages.mermaid-cli -- -i input.mmd -o output.svg
+nix run nixpkgs#python3Packages.grip -- README.md
+
+# Enter a project shell with tools available:
+nix develop github:JacobPEvans/nix-devenv?dir=shells/ansible
+nix develop github:JacobPEvans/nix-devenv?dir=shells/kubernetes
+
+# Use uvx for Python CLIs (preferred over pipx in Nix):
+uvx aider-chat
+uvx ruff check .
+```
+
+## Quartet Repo Responsibilities
+
+| Repo | Scope |
+| --- | --- |
+| **nix-darwin** | macOS system config: system packages, Homebrew, security, GUI apps, LaunchDaemons |
+| **nix-ai** | AI tool ecosystem: Claude Code, Gemini, MCP servers, whisper stack, AI CLIs |
+| **nix-home** | User dev environment: dev tools, shell config, git, linters, credentials |
+| **nix-devenv** | Reusable project shells and importable modules: per-language toolchains |
+
+Full package lists live in each repo's source files — this rule contains placement logic only.

--- a/agentsmd/rules/nix-package-placement.md
+++ b/agentsmd/rules/nix-package-placement.md
@@ -47,7 +47,7 @@ editor integration because IDEs activate the system environment, not a project s
 ```bash
 # Zero-install ephemeral runs (like bunx but for Nix):
 nix run nixpkgs#d2 -- input.d2 output.svg
-nix run nixpkgs#nodePackages.mermaid-cli -- -i input.mmd -o output.svg
+nix run nixpkgs#mermaid-cli -- -i input.mmd -o output.svg
 nix run nixpkgs#python3Packages.grip -- README.md
 
 # Enter a project shell with tools available:

--- a/agentsmd/rules/nix-package-placement.md
+++ b/agentsmd/rules/nix-package-placement.md
@@ -1,5 +1,5 @@
 ---
-description: Package placement decision matrix for the nix-darwin / nix-ai / nix-home / nix-devenv quartet — where tools belong and when to use nix run instead
+description: Package placement decision matrix for the nix repos — where tools belong and when to use nix run instead
 paths:
   - "**/*.nix"
   - "flake.nix"
@@ -8,7 +8,15 @@ paths:
 
 # Nix Package Placement
 
-Three tiers. Place a tool in the lowest tier that satisfies all its requirements.
+Prefer the most ephemeral install that still meets the tool's real requirements.
+Promote a tool from ephemeral to project-scoped (devenv shell) only when running
+it on-demand is too slow; promote from project-scoped to always-on (`home.packages`
+or `environment.systemPackages`) only when it must be on `$PATH` everywhere,
+outside any project context.
+
+The table below is ordered the same way — always-on at the top, ephemeral at the
+bottom. Work upward from the bottom of the table; stop at the first row that
+satisfies your tool's needs.
 
 ## Placement Decision Matrix
 
@@ -59,7 +67,7 @@ uvx aider-chat
 uvx ruff check .
 ```
 
-## Quartet Repo Responsibilities
+## Repo Responsibilities
 
 | Repo | Scope |
 | --- | --- |
@@ -69,3 +77,5 @@ uvx ruff check .
 | **nix-devenv** | Reusable project shells and importable modules: per-language toolchains |
 
 Full package lists live in each repo's source files — this rule contains placement logic only.
+Adding a repo to this set? Update this table, the decision matrix categories above,
+and `AGENTS.md` in each consumer repo that references the rule.


### PR DESCRIPTION
## Summary

Adds `agentsmd/rules/nix-package-placement.md` — a path-scoped rule (auto-loads for `*.nix`, `flake.*` files) that centralizes the package placement decision logic for the nix quartet.

Replaces duplicated inline "Package placement" sections across all four `CLAUDE.md`/`AGENTS.md` files.

### What the rule covers

- **Three-tier placement model**: always-on → project-on-demand → ephemeral
- **Decision matrix table**: category → correct repo/mechanism
- **Critical constraints**:
  - Homebrew: `homebrew.*` is nix-darwin-only; home-manager cannot declare brew formulas
  - pre-commit `language: system`: tool must be in global PATH
  - IDE linters: pyright/similar must stay in global home.packages
- **On-demand patterns**: `nix run nixpkgs#<pkg>`, `uvx`, `bunx` examples

### AGENTS.md update

Added one-line entry in the Path-scoped rules section pointing to the new rule.

## Test plan

- [ ] All pre-commit hooks pass (markdownlint, cspell, lychee)
- [ ] Rule file renders correctly in GitHub
- [ ] `@agentsmd/rules/nix-package-placement.md` resolves when `.nix` files are in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)