### PR TITLE
fix(routing): swap broken Qwen3.5-35B-A3B-4bit to Qwen3-Coder-30B-A3B-Instruct-4bit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,9 +140,9 @@ This is about output format, not thinking. Reason thoroughly. Write concisely.
 | Fast Tasks | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-6` | mlx-community/Qwen3.5-27B-4bit |
 | Code Review | Multi-model consensus | Multiple Bifrost calls + PAL `consensus` | mlx-community/Qwen3.5-27B-4bit |
 | Architecture | Claude Opus 4.6 | `anthropic/claude-opus-4-6` | mlx-community/Qwen3-235B-A22B-4bit |
-| Pre-commit | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-6` | mlx-community/Qwen3.5-35B-A3B-4bit |
+| Pre-commit | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-6` | mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit |
 
-Default local model: `mlx-community/Qwen3.5-27B-4bit` (always loaded).
+Default local model: `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` (always loaded).
 Larger models are on-demand via `mlx-switch`. Run `listmodels` for available models and aliases.
 
 ## PAL MCP Tools


### PR DESCRIPTION
## Summary

- Update AGENTS.md Model Routing Rules table to replace the multimodal-broken `mlx-community/Qwen3.5-35B-A3B-4bit` with its benchmark-winning replacement `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`.
- Keeps the user-global routing config in sync with JacobPEvans/nix-ai#470 (the Nix \`programs.mlx.defaultModel\` swap).

## Context

On 2026-02-24, HuggingFace upstream silently republished \`mlx-community/Qwen3.5-35B-A3B-4bit\` as a multimodal variant (\`Qwen3_5MoeForConditionalGeneration\`, \`pipeline_tag: image-text-to-text\`, sha \`1e20fd8d42056f870933bf98ca6211024744f7ec\`). vllm-mlx 0.2.6 cannot load it — every fresh Claude/Gemini/Codex session that routed to this model raised a \`TypeError: cannot unpack non-iterable NoneType object\` from \`load_model_with_fallback\`.

JacobPEvans/nix-ai#470 shipped the Nix-side fix yesterday, swapping \`programs.mlx.defaultModel\` to the Phase B math-hard sweep winner (\`Qwen3-Coder-30B-A3B-Instruct-4bit\`, 0.47 math_verify on minerva_math500 @ 100 samples, leads the runner-up by 5 pp). But the user-global Model Routing Rules table in \`AGENTS.md\` (canonical source for \`CLAUDE.md\` and \`GEMINI.md\` via symlink) was never updated to match.

Without this fix, fresh sessions will keep routing pre-commit tasks to the dead model.

## Changes

- \`AGENTS.md:143\` — Pre-commit row local MLX column updated
- \`AGENTS.md:145\` — \"Default local model (always loaded)\" updated to match llama-swap's new ttl:0 preload

\`CLAUDE.md\` and \`GEMINI.md\` are symlinks to \`AGENTS.md\` so both pick up the change automatically.

## Test plan

- [x] Pre-commit hooks (markdownlint, cspell, link-check) pass
- [ ] Human review + merge
- [ ] Post-merge: \`darwin-rebuild switch\` in nix-darwin/nix-home to propagate
- [ ] Fresh Claude Code session: confirm routing table reflects new default