### PR TITLE
fix(permissions): add obsidian CLI to allow and ask lists

### DIFF
--- a/agentsmd/permissions/allow/tools.json
+++ b/agentsmd/permissions/allow/tools.json
@@ -61,6 +61,7 @@
     "playwright",
     "ruff",
     "tflint",
-    "yamllint"
+    "yamllint",
+    "obsidian"
   ]
 }

--- a/agentsmd/permissions/ask/system.json
+++ b/agentsmd/permissions/ask/system.json
@@ -20,6 +20,8 @@
     "softwareupdate",
     "sqlite3",
     "ssh-keygen",
-    "system_profiler"
+    "system_profiler",
+    "obsidian eval",
+    "obsidian trash"
   ]
 }


### PR DESCRIPTION
# PR #556: Obsidian CLI Permissions

## Summary

Adds `obsidian` CLI to permissions with a coarse-allow pattern for all safe read/write commands, plus specific per-command approval rules for dangerous operations.

Enables the Obsidian skills Claude Code plugin to invoke the official Obsidian CLI (v1.8+, bundled in Obsidian.app) without interactive prompts for safe operations.

## Changes

- Added `obsidian` to `agentsmd/permissions/allow/tools.json` (auto-approves 78+ safe subcommands via `Bash(obsidian *)`)
- Added `obsidian eval` and `obsidian trash` to `agentsmd/permissions/ask/system.json` (per STRATEGY.md pattern: coarse-allow + specific-ask for risky operations)

## Test Plan

- [ ] Merge PR and update nix-ai flake input in nix-darwin
- [ ] Run `darwin-rebuild switch` with updated ai-assistant-instructions
- [ ] Verify `Bash(obsidian *)` appears in `~/.claude/settings.json` under `permissions.allow`
- [ ] Verify `ask/system` contains `obsidian eval` and `obsidian trash`
- [ ] Start fresh Claude Code session
- [ ] Confirm safe commands like `obsidian help` and `obsidian vault list` auto-approve without interactive prompt
- [ ] Confirm dangerous commands like `obsidian eval` and `obsidian trash` trigger approval flow
