### PR TITLE
fix: add automation bots to AI Moderator skip-bots

### DIFF
--- a/.github/workflows/ai-moderator.lock.yml
+++ b/.github/workflows/ai-moderator.lock.yml
@@ -1004,7 +1004,7 @@ jobs:
         id: check_skip_bots
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          GH_AW_SKIP_BOTS: "github-actions,copilot"
+          GH_AW_SKIP_BOTS: "github-actions,copilot,renovate,dependabot,release-please,jacobpevans-github-actions"
           GH_AW_WORKFLOW_NAME: "AI Moderator"
         with:
           script: |

--- a/.github/workflows/ai-moderator.lock.yml
+++ b/.github/workflows/ai-moderator.lock.yml
@@ -58,6 +58,10 @@ name: "AI Moderator"
   # skip-bots: # Skip-bots processed as bot check in pre-activation job
   # - github-actions # Skip-bots processed as bot check in pre-activation job
   # - copilot # Skip-bots processed as bot check in pre-activation job
+  # - renovate # Skip-bots processed as bot check in pre-activation job
+  # - dependabot # Skip-bots processed as bot check in pre-activation job
+  # - release-please # Skip-bots processed as bot check in pre-activation job
+  # - jacobpevans-github-actions # Skip-bots processed as bot check in pre-activation job
   # skip-roles: # Skip-roles processed as role check in pre-activation job
   # - admin # Skip-roles processed as role check in pre-activation job
   # - maintainer # Skip-roles processed as role check in pre-activation job

--- a/.github/workflows/ai-moderator.md
+++ b/.github/workflows/ai-moderator.md
@@ -14,7 +14,7 @@ on:
     types: [opened]
     forks: "*"
   skip-roles: [admin, maintainer, write, triage]
-  skip-bots: [github-actions, copilot]
+  skip-bots: [github-actions, copilot, renovate, dependabot, release-please, jacobpevans-github-actions]
 permissions:
   contents: read
   issues: read


### PR DESCRIPTION
# PR #572 Update

## Summary

Adds `renovate`, `dependabot`, `release-please`, and `jacobpevans-github-actions`
to the AI Moderator `skip-bots` list to prevent automation-triggered PRs from
burning AI credits.

These bots have `permission: none` on repositories (GitHub App model), so the
existing role-based skip logic doesn't catch them. Without this fix, every
Renovate/Dependabot/release-please PR triggers a full AI agent run.

## Changes

- `.github/workflows/ai-moderator.md`: Updated `skip-bots` frontmatter to
  include new bot names
- `.github/workflows/ai-moderator.lock.yml`: Updated `GH_AW_SKIP_BOTS`
  environment variable in compiled workflow

## Test Plan

- [ ] Verify that Renovate PRs no longer trigger AI Moderator agent runs
- [ ] Verify that Dependabot PRs no longer trigger AI Moderator agent runs
- [ ] Verify that release-please PRs no longer trigger AI Moderator agent runs
- [ ] Verify that manual PRs and legitimate bot PRs still trigger AI Moderator
  as expected

🤖 Generated with Claude Code
