### PR TITLE
fix: remove version-pinned Claude model references

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -15,7 +15,8 @@
     "Nomic",
     "nomic",
     "agentics",
-    "githubnext"
+    "githubnext",
+    "listmodels"
   ],
   "files": ["**/*.md", "/tmp/*.md"],
   "ignorePaths": [".git", "node_modules", ".github/aw/**"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ Claude Opus tokens are premium — reserve them for architecture decisions and c
 Offload everything else:
 
 - **Single-model calls**: Route via Bifrost at `http://localhost:30080/v1/chat/completions` (OpenAI-compatible) —
-  multi-provider routing to OpenAI, Gemini, Anthropic, OpenRouter, and local MLX
+  multi-provider routing to OpenAI, Gemini, OpenRouter, and local MLX
+  (not Anthropic — Claude runs subscription-only via Claude Code; Codex also accessible via `/codex*` skills)
 - **Multi-model parallel**: `clink` / `consensus` via PAL MCP (only remaining PAL tools — all others replaced by native subagents)
 - **Research & planning**: Route to Gemini via Bifrost (`gemini/gemini-3-pro-preview`) or `clink` (multi-model parallel) —
   up-to-date knowledge and massive context
@@ -136,11 +137,11 @@ This is about output format, not thinking. Reason thoroughly. Write concisely.
 | Task Type | Cloud Model | Bifrost Path | Local (MLX) |
 | --- | --- | --- | --- |
 | Research & Analysis | Gemini 3 Pro | `gemini/gemini-3-pro-preview` | mlx-community/Qwen3-235B-A22B-4bit |
-| Complex Coding | Claude Opus 4.6 | `anthropic/claude-opus-4-6` | mlx-community/Qwen3.5-122B-A10B-4bit |
-| Fast Tasks | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-6` | mlx-community/Qwen3.5-27B-4bit |
+| Complex Coding | Claude Opus | Claude Code (subscription) | mlx-community/Qwen3.5-122B-A10B-4bit |
+| Fast Tasks | Claude Sonnet | Claude Code (subscription) | mlx-community/Qwen3.5-27B-4bit |
 | Code Review | Multi-model consensus | Multiple Bifrost calls + PAL `consensus` | mlx-community/Qwen3.5-27B-4bit |
-| Architecture | Claude Opus 4.6 | `anthropic/claude-opus-4-6` | mlx-community/Qwen3-235B-A22B-4bit |
-| Pre-commit | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4-6` | mlx-community/Qwen3.5-35B-A3B-4bit |
+| Architecture | Claude Opus | Claude Code (subscription) | mlx-community/Qwen3-235B-A22B-4bit |
+| Pre-commit | Claude Sonnet | Claude Code (subscription) | mlx-community/Qwen3.5-35B-A3B-4bit |
 
 Default local model: `mlx-community/Qwen3.5-27B-4bit` (always loaded).
 Larger models are on-demand via `mlx-switch`. Run `listmodels` for available models and aliases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ This is about output format, not thinking. Reason thoroughly. Write concisely.
 
 ## Model Routing Rules
 
-| Task Type | Cloud Model | Bifrost Path | Local (MLX) |
+| Task Type | Cloud Model | Access Method | Local (MLX) |
 | --- | --- | --- | --- |
 | Research & Analysis | Gemini 3 Pro | `gemini/gemini-3-pro-preview` | mlx-community/Qwen3-235B-A22B-4bit |
 | Complex Coding | Claude Opus | Claude Code (subscription) | mlx-community/Qwen3.5-122B-A10B-4bit |

--- a/scripts/select-model.sh
+++ b/scripts/select-model.sh
@@ -201,11 +201,11 @@ select_model() {
   # Step 5: Need specialized coding?
   if [[ "$task_type" == "coding" ]]; then
     if [[ "$complexity" == "high" ]]; then
-      echo "Model: claude-opus-4-5"
+      echo "Model: claude-opus"
       echo "Command: Using Claude directly (current session)"
       echo "Rationale: High-complexity coding task - Claude Opus for superior architecture and reasoning"
     else
-      echo "Model: claude-sonnet-4-5"
+      echo "Model: claude-sonnet"
       echo "Command: Using Claude directly (current session)"
       echo "Rationale: Standard coding task - Claude Sonnet for efficient code generation"
     fi
@@ -216,7 +216,7 @@ select_model() {
   if [[ "$task_type" == "review" ]]; then
     if [[ "$complexity" == "high" ]]; then
       echo "Model: consensus"
-      echo "Selected: claude-opus-4-5 + gemini-3-pro + deepseek-r1:70b (local)"
+      echo "Selected: claude-opus + gemini-3-pro + deepseek-r1:70b (local)"
       echo "Command: Multi-model review for high-complexity code"
       echo "Rationale: High-complexity review requires expert perspectives - adding Opus for deeper analysis"
     else

--- a/scripts/select-model.sh
+++ b/scripts/select-model.sh
@@ -201,11 +201,11 @@ select_model() {
   # Step 5: Need specialized coding?
   if [[ "$task_type" == "coding" ]]; then
     if [[ "$complexity" == "high" ]]; then
-      echo "Model: claude-opus"
+      echo "Model: Claude Opus (Claude Code)"
       echo "Command: Using Claude directly (current session)"
       echo "Rationale: High-complexity coding task - Claude Opus for superior architecture and reasoning"
     else
-      echo "Model: claude-sonnet"
+      echo "Model: Claude Sonnet (Claude Code)"
       echo "Command: Using Claude directly (current session)"
       echo "Rationale: Standard coding task - Claude Sonnet for efficient code generation"
     fi
@@ -216,7 +216,7 @@ select_model() {
   if [[ "$task_type" == "review" ]]; then
     if [[ "$complexity" == "high" ]]; then
       echo "Model: consensus"
-      echo "Selected: claude-opus + gemini-3-pro + deepseek-r1:70b (local)"
+      echo "Selected: Claude Opus (Claude Code) + gemini-3-pro + deepseek-r1:70b (local)"
       echo "Command: Multi-model review for high-complexity code"
       echo "Rationale: High-complexity review requires expert perspectives - adding Opus for deeper analysis"
     else


### PR DESCRIPTION
# fix: remove version-pinned Claude model references

## Summary

- Remove versioned Claude model names (`4.6`, `4.5`) from the Model Routing Rules table
  and `select-model.sh` — eliminates manual updates each model version bump
- Rename "Bifrost Path" column to "Access Method" for semantic consistency:
  Claude rows use subscription access, not Bifrost API paths
- Clarify that Claude is subscription-only via Claude Code (not Bifrost) and that
  Codex is accessed directly via `/codex*` skills
- Fix `select-model.sh` echo output from hardcoded version strings to tier names
  (`Claude Opus (Claude Code)` / `Claude Sonnet (Claude Code)`)
- Add the `list-models` alias to the cspell words list (pre-existing term in `AGENTS.md`)

## Changes

- **`AGENTS.md`** — Model Routing Rules table: stripped version suffixes from Claude rows,
  renamed "Bifrost Path" column to "Access Method", updated Claude access cells to
  `Claude Code (subscription)`, added Codex note for `/codex*` skills
- **`scripts/select-model.sh`** — Echo output updated to use tier names instead of
  version-pinned model IDs
- **`.cspell.json`** — Added the model-listing command to the words allowlist

## Test Plan

- [x] All pre-commit hooks pass (markdownlint, cspell, lychee, check-markdown-links)
- [x] Zero grep matches for versioned Claude model strings in `AGENTS.md`
  and `scripts/select-model.sh`
- [x] `select-model.sh` echo output reflects tier names, not version-pinned IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
