### PR TITLE
docs: clarify mlx-local/ Bifrost prefix in model routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,17 +134,22 @@ This is about output format, not thinking. Reason thoroughly. Write concisely.
 
 ## Model Routing Rules
 
-| Task Type | Cloud Model | Access Method | Local (MLX) |
+| Task Type | Cloud Model | Access Method | Local (MLX via Bifrost) |
 | --- | --- | --- | --- |
-| Research & Analysis | Gemini 3 Pro | `gemini/gemini-3-pro-preview` | mlx-community/Qwen3-235B-A22B-4bit |
-| Complex Coding | Claude Opus | Claude Code (subscription) | mlx-community/Qwen3.5-122B-A10B-4bit |
-| Fast Tasks | Claude Sonnet | Claude Code (subscription) | mlx-community/Qwen3.5-27B-4bit |
-| Code Review | Multi-model consensus | Multiple Bifrost calls + PAL `consensus` | mlx-community/Qwen3.5-27B-4bit |
-| Architecture | Claude Opus | Claude Code (subscription) | mlx-community/Qwen3-235B-A22B-4bit |
-| Pre-commit | Claude Sonnet | Claude Code (subscription) | mlx-community/Qwen3.5-35B-A3B-4bit |
+| Research & Analysis | Gemini 3 Pro | `gemini/gemini-3-pro-preview` | `mlx-local/mlx-community/Qwen3-235B-A22B-4bit` |
+| Complex Coding | Claude Opus | Claude Code (subscription) | `mlx-local/mlx-community/Qwen3.5-122B-A10B-4bit` |
+| Fast Tasks | Claude Sonnet | Claude Code (subscription) | `mlx-local/mlx-community/Qwen3.5-27B-4bit` |
+| Code Review | Multi-model consensus | Multiple Bifrost calls + PAL `consensus` | `mlx-local/mlx-community/Qwen3.5-27B-4bit` |
+| Architecture | Claude Opus | Claude Code (subscription) | `mlx-local/mlx-community/Qwen3-235B-A22B-4bit` |
+| Pre-commit | Claude Sonnet | Claude Code (subscription) | `mlx-local/mlx-community/Qwen3.5-35B-A3B-4bit` |
 
-Default local model: `mlx-community/Qwen3.5-27B-4bit` (always loaded).
+Default local model: `mlx-local/mlx-community/Qwen3.5-27B-4bit` (always loaded).
 Larger models are on-demand via `mlx-switch`. Run `listmodels` for available models and aliases.
+
+> **Bifrost prefix required**: Local MLX models must use the `mlx-local/` provider prefix
+> when routing through Bifrost (e.g. `mlx-local/mlx-community/Qwen3.5-27B-4bit`).
+> PAL MCP's `custom_models.json` and `CUSTOM_MODEL_NAME` are pre-configured with this prefix.
+> Use bare `mlx-community/` names only when calling the vllm-mlx server directly (port 11434).
 
 ### Provider Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,11 @@ This is about output format, not thinking. Reason thoroughly. Write concisely.
 Default local model: `mlx-local/mlx-community/Qwen3.5-27B-4bit` (always loaded).
 Larger models are on-demand via `mlx-switch`. Run `listmodels` for available models and aliases.
 
-> **Bifrost prefix required**: Local MLX models must use the `mlx-local/` provider prefix
-> when routing through Bifrost (e.g. `mlx-local/mlx-community/Qwen3.5-27B-4bit`).
-> PAL MCP's `custom_models.json` and `CUSTOM_MODEL_NAME` are pre-configured with this prefix.
-> Use bare `mlx-community/` names only when calling the vllm-mlx server directly (port 11434).
+> **Bifrost prefix required**: This `mlx-local/` prefix is a Bifrost-only exception to the
+> general advice elsewhere not to add provider-style prefixes to local model names for
+> PAL/OpenRouter routing. PAL MCP's `custom_models.json` and `CUSTOM_MODEL_NAME` are
+> pre-configured with this prefix. Use bare `mlx-community/` names only when calling the
+> vllm-mlx server directly (port 11434).
 
 ### Provider Gotchas
 


### PR DESCRIPTION
# Clarify mlx-local/ Bifrost prefix in model routing docs

## Summary

Bifrost requires the `mlx-local/` prefix for local MLX model routing, but AGENTS.md
previously stated "never add provider-style prefixes." This PR clarifies that
`mlx-local/` is a Bifrost-only exception and updates the Model Routing Rules table
to reflect correct prefixes.

## Changes

- Updated **Model Routing Rules** table column header from "Local (MLX)" to
  "Local (MLX via Bifrost)"
- Updated all 6 model entries from bare `mlx-community/<name>` to
  `mlx-local/mlx-community/<name>` with code backticks
- Updated default local model line: `mlx-community/Qwen3.5-27B-4bit` →
  `mlx-local/mlx-community/Qwen3.5-27B-4bit`
- Added a blockquote note explaining `mlx-local/` is a Bifrost-only exception
  to the no-prefix rule elsewhere in the document

## Motivation

The previous doc created confusion: it warned against provider-style prefixes
like `custom/` or `ollama/`, but Bifrost's local MLX routing requires
`mlx-local/`. This clarifies when to use each format and why.

## Test plan

- [x] Doc changes only (no code changes, no tests needed)
- [x] Formatting verified (markdown syntax, inline code backticks)
- [x] Blockquote rendered correctly

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
