### PR TITLE
chore: forbid emoji in commit messages and PR titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,10 @@ write concisely.
 
 ## Commit & PR Style
 
-No emoji or gitmoji in commit messages, PR titles, or PR descriptions.
-Conventional-commit prefixes only (`feat:`, `fix:`, `chore:`, etc.).
+No emoji or gitmoji in commit messages, PR titles, PR descriptions, or
+release notes. Conventional-commit prefixes (`feat:`, `fix:`, `chore:`,
+etc.) apply to commit subjects and PR titles only — descriptions and
+release notes are plain prose.
 Applies to AI-authored and AI-assisted commits/PRs alike — no `🤖`, no
 `✨`, no `🐛`. Plain text wins.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,13 @@ Preserve depth where it matters: complex reasoning, architecture decisions,
 and error diagnosis (root cause, not just the fix). Reason thoroughly,
 write concisely.
 
+## Commit & PR Style
+
+No emoji or gitmoji in commit messages, PR titles, or PR descriptions.
+Conventional-commit prefixes only (`feat:`, `fix:`, `chore:`, etc.).
+Applies to AI-authored and AI-assisted commits/PRs alike — no `🤖`, no
+`✨`, no `🐛`. Plain text wins.
+
 ## Model Routing
 
 Reference task classes, not specific model names. Identifiers rot — resolve

--- a/agentsmd/rules/soul.md
+++ b/agentsmd/rules/soul.md
@@ -27,7 +27,7 @@ description: AI personality and voice — playful professional who ships quality
 
 ## 4. Communication Patterns
 
-- Gitmoji in commits, release notes, and PR descriptions
+- No emoji in commit messages, PR titles, PR descriptions, or release notes — plain conventional commits only
 - Emoji in READMEs and docs should be minimal and purposeful, not flooded
 - Complexity-based verbosity: TLDR for simple, narrative for complex
 
@@ -36,7 +36,7 @@ description: AI personality and voice — playful professional who ships quality
 - DO keep solutions simple -> DON'T over-engineer
 - DO understand patterns before using them -> DON'T cargo cult
 - DO document as you go -> DON'T leave documentation debt
-- DO use emoji purposefully -> DON'T flood everything with emoji
+- DO keep prose emoji minimal and purposeful -> DON'T put any emoji in commits, PR titles, or PR bodies
 - DO tell hard truths directly -> DON'T be sycophantic
 - DO disagree when you disagree -> DON'T soften unnecessarily
 

--- a/agentsmd/rules/soul.md
+++ b/agentsmd/rules/soul.md
@@ -27,7 +27,8 @@ description: AI personality and voice — playful professional who ships quality
 
 ## 4. Communication Patterns
 
-- No emoji in commit messages, PR titles, PR descriptions, or release notes — plain conventional commits only
+- No emoji in commit messages, PR titles, PR descriptions, or release notes
+- Conventional-commit prefixes (`feat:`, `fix:`, `chore:`, etc.) for commit subjects and PR titles only
 - Emoji in READMEs and docs should be minimal and purposeful, not flooded
 - Complexity-based verbosity: TLDR for simple, narrative for complex
 
@@ -36,7 +37,7 @@ description: AI personality and voice — playful professional who ships quality
 - DO keep solutions simple -> DON'T over-engineer
 - DO understand patterns before using them -> DON'T cargo cult
 - DO document as you go -> DON'T leave documentation debt
-- DO keep prose emoji minimal and purposeful -> DON'T put any emoji in commits, PR titles, or PR bodies
+- DO keep prose emoji minimal and purposeful -> DON'T put any emoji in commit messages, PR titles, PR descriptions, or release notes
 - DO tell hard truths directly -> DON'T be sycophantic
 - DO disagree when you disagree -> DON'T soften unnecessarily
 


### PR DESCRIPTION
## Summary

- Flip `agentsmd/rules/soul.md` line 30 from *Gitmoji in commits, release notes, and PR descriptions* to an explicit ban
- Tighten the related DO/DON'T line on line 39
- Add a brief `## Commit & PR Style` section to `AGENTS.md`

## Problem

`soul.md` has, since its creation on 2026-12-06 (commit `a2a4bd2`, untouched ever since), actively endorsed gitmoji in commits and PR descriptions. Because `soul.md` is in the universal auto-loaded ruleset, every Claude Code session has been told to reach for emoji prefixes. Recent automated AI-fix PRs (e.g. claude-code-plugins #257, #263) landed with `🤖` prefixes as a direct consequence — the rule was working as written.

This was never a "no emoji" rule we lost. It's a rule we never had — until now.

## Scope

Per user selection:

- ✅ Commit messages
- ✅ PR titles + descriptions
- ✅ Release notes
- ❌ Prose emoji in READMEs/docs (untouched — `soul.md` line 31 still permits "minimal and purposeful")

## Companion PR

Reinforced in `claude-code-plugins` so the on-demand `/pr-standards` and `/git-workflow-standards` skills carry the rule too. Three layers of defense: universal auto-load (soul.md), top-level orchestrator doc (AGENTS.md), on-demand skill (pr-standards).

## Test plan

- [x] Pre-commit hooks pass (markdownlint, link-check, etc.)
- [x] \`grep -rn -i "gitmoji" agentsmd/ AGENTS.md\` shows no remaining endorsement
- [ ] Next AI-authored commit/PR in this repo lands without emoji

(claude)