### PR TITLE
chore: add scope boundary rule and trim AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AI Agents Configuration
 
-Commands, skills, agents, and hooks from [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins).
+Commands, skills, agents, and hooks are delivered via [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins).
 
 ## Starting Any Change
 
@@ -35,7 +35,7 @@ Use a cheap model via Bifrost (`listmodels`) + Context7; include a one-line-per-
 ### The 10-Line Gate
 
 Auto-approval only when search is empty AND the script is under 10 non-comment lines
-(shebang and code lines count; blank and pure-comment lines don't; no semicolon-stuffing).
+(shebang, code, heredoc/multi-line-string, and continuation lines count; blank and pure-comment lines don't; no semicolon-stuffing).
 At 10+, ASK and wait for an unambiguous yes. Hook blocks are TERMINAL DENIALS.
 
 ## Orchestrator Role

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,10 @@ Before any script or inline code with logic, search and document each tier:
 1. **Native CLIs / builtins** — `jq`, `gh`, `git`, `curl`, system utilities
 2. **Ecosystem primitives** — Ansible modules, Terraform resources, Nix functions, marketplace Actions, pre-commit hooks
 3. **Third-party packaged tools** — Homebrew, apt, pip, npm, cargo
-4. **Popular community solutions** — well-starred GitHub projects, official plugins
+4. **Popular community solutions** — well-starred GitHub projects, official plugins, awesome-* lists
 
-Use a cheap model via Bifrost (`listmodels`) + Context7; include a one-line-per-tier search log in your reply — empty rows are rejected.
+Use a cheap model via Bifrost (`listmodels`) + Context7; include a one-line-per-tier search log
+(tool → found/not found, reason) — empty rows or "n/a" are rejected.
 
 ### The 10-Line Gate
 
@@ -61,7 +62,7 @@ See the `tool-use` rule.
 
 ## Commit & PR Style
 
-See `agentsmd/rules/soul.md` §4 — no emoji; conventional-commit prefixes for subjects/titles; plain prose everywhere else.
+See soul.md section 4 — no emoji; conventional-commit prefixes for subjects/titles; plain prose everywhere else.
 
 ## Model Routing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,102 +1,71 @@
 # AI Agents Configuration
 
-Multi-model AI orchestration for Claude, Gemini, Copilot, Codex, and local models.
-Commands, skills, agents, and hooks are delivered as plugins from
-[JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins).
+Commands, skills, agents, and hooks from [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins).
 
 ## Starting Any Change
 
 Run `/refresh-repo`, then create a worktree at `~/git/<repo>/<type>/<name>`
 on a `<type>/<name>` branch off `main`. No exceptions.
 
+## Scope Boundary
+
+Always one-shot a working local solution. You may mention a suspected upstream
+bug as an FYI to the user, but never file issues, open PRs, or push fixes to
+upstream projects outside the user's organizations.
+
+If a true one-shot is not achievable, recommend creating GitHub issues in the
+user's own repos for persistent tracking — do not use Claude Code's internal
+TODO system as a substitute for durable issue tracking.
+
 ## No Scripts — Iron Law
 
-**A custom script is the LAST RESORT, never the first. Anything you can write
-is already worse-maintained than something that already exists. Search first,
-script only when every tier comes up empty AND the user explicitly approves.**
+**A custom script is the LAST RESORT. Search first, script only when every tier comes up empty AND the user explicitly approves.**
 
 ### Mandatory Search (every tier, every time)
 
-Before any `.sh` / `.py` / `.ts` / `.js` / `.rb` / `.pl` or inline
-`python -c` / `bash -c` / `node -e` body that contains logic, search and
-document each tier:
+Before any script or inline code with logic, search and document each tier:
 
 1. **Native CLIs / builtins** — `jq`, `gh`, `git`, `curl`, system utilities
-2. **Ecosystem primitives** — Ansible modules, Terraform resources, Nix
-   functions, marketplace GitHub Actions, pre-commit hooks
+2. **Ecosystem primitives** — Ansible modules, Terraform resources, Nix functions, marketplace Actions, pre-commit hooks
 3. **Third-party packaged tools** — Homebrew, apt, pip, npm, cargo
-4. **Popular community solutions** — well-starred GitHub projects, official
-   plugins, awesome-* lists
+4. **Popular community solutions** — well-starred GitHub projects, official plugins
 
-The search MUST be assisted by a cheap model via Bifrost (no hardcoded model
-ids — use `listmodels`) AND cross-checked with Context7. Training data is
-stale; do not trust it.
-
-In your reply, include a one-line-per-tier search log: tool searched →
-found / not found, with a reason if not found. Empty rows or "n/a" are
-rejected.
+Use a cheap model via Bifrost (`listmodels`) + Context7; include a one-line-per-tier search log in your reply — empty rows are rejected.
 
 ### The 10-Line Gate
 
-Auto-approval applies ONLY when the search comes up empty AND the script
-is under **10 non-comment lines**. Counting: shebang counts; every code
-line, heredoc/multi-line-string line, and continuation line counts; blank
-and pure-comment lines don't; no semicolon-stuffing.
-
-At 10+ non-comment lines, ASK the user explicitly and wait for an
-unambiguous yes. Hook blocks are TERMINAL DENIALS, not menus of fallbacks.
+Auto-approval only when search is empty AND the script is under 10 non-comment lines
+(shebang and code lines count; blank and pure-comment lines don't; no semicolon-stuffing).
+At 10+, ASK and wait for an unambiguous yes. Hook blocks are TERMINAL DENIALS.
 
 ## Orchestrator Role
 
-You are a master orchestrator. Your primary context window is precious:
-it is where decisions are made, plans are formed, and results are synthesized.
-Protect it. Delegate exploration, verification, and high-token operations to
-subagents — they return only what matters.
-
-Never use `subagent_type: "Bash"` for tasks that read, write, or edit files
-(Bash agents fall back to `sed` / `awk` / `python -c` and bypass audit).
-Use `general-purpose`. See the `tool-use` rule.
+Protect your context window — delegate exploration and high-token operations to subagents.
+Never use `subagent_type: "Bash"` for file reads/writes/edits; use `general-purpose`.
+See the `tool-use` rule.
 
 ## Token Economy — Use Bifrost + Native Subagents Aggressively
 
-Top-tier reasoning models are premium. Reserve them for architecture
-decisions and complex coding. Offload everything else:
-
 - **Single-model calls**: Bifrost at `http://localhost:30080/v1/chat/completions`
 - **Multi-model parallel / agreement**: PAL MCP `clink` / `consensus`
-- **Research, planning, simple / repetitive tasks**: route to local MLX or
-  cheaper cloud models via Bifrost — zero or near-zero cost
+- **Research, planning, simple / repetitive tasks**: local MLX or cheap cloud via Bifrost
 - **External-model delegation**: `/delegate-to-ai`
-- **Day-to-day implementation**: prefer Sonnet-class subagents over Opus-class
+- **Day-to-day implementation**: prefer Sonnet-class over Opus-class
 
 ## Output Format
 
-Optimize for information density. Every token emitted consumes the user's
-context window.
-
-- Lead with the result. No preamble, no narration of intent.
-- Short, direct sentences. Cut filler.
-- Tools first, explanation after.
-- Tables and lists over prose for structured data.
-- One-line acknowledgments for simple confirmations.
-
-Preserve depth where it matters: complex reasoning, architecture decisions,
-and error diagnosis (root cause, not just the fix). Reason thoroughly,
-write concisely.
+- Lead with the result. No preamble.
+- Short sentences. Tools before explanation. Tables over prose.
+- One-line acks for simple confirmations.
+- Preserve depth for root cause analysis and architecture decisions.
 
 ## Commit & PR Style
 
-No emoji or gitmoji in commit messages, PR titles, PR descriptions, or
-release notes. Conventional-commit prefixes (`feat:`, `fix:`, `chore:`,
-etc.) apply to commit subjects and PR titles only — descriptions and
-release notes are plain prose.
-Applies to AI-authored and AI-assisted commits/PRs alike — no `🤖`, no
-`✨`, no `🐛`. Plain text wins.
+See `agentsmd/rules/soul.md` §4 — no emoji; conventional-commit prefixes for subjects/titles; plain prose everywhere else.
 
 ## Model Routing
 
-Reference task classes, not specific model names. Identifiers rot — resolve
-them at call time via `listmodels`.
+Resolve model names at call time via `listmodels`.
 
 | Task class | Where to route |
 | --- | --- |
@@ -106,20 +75,14 @@ them at call time via `listmodels`.
 | Code review | Multi-model `consensus` or local MLX via Bifrost |
 | Pre-commit checks | Sonnet-class or local MLX via Bifrost |
 
-Bifrost-specific routing details (prefix conventions, PAL tools, local-only
-mode) live in the `bifrost-routing` rule, lazy-loaded only when relevant
-files are in context.
+Bifrost routing details in the `bifrost-routing` rule (lazy-loaded).
 
 ## Auto-Loaded Rules
 
-Rules are sourced from `agentsmd/rules/` via `.claude/rules/`.
+Sources: `agentsmd/rules/` via `.claude/rules/`.
 
-**Universal (every session):**
-`tool-use`, `soul`, `skill-execution-integrity`, `secrets-policy`.
-
-**Path-scoped (lazy-load on matching files):**
-`nix-tool-policy`, `nix-package-placement`, `ci-cd-policy`, `config-secrets`,
-`bifrost-routing`.
+**Universal:** `tool-use`, `soul`, `skill-execution-integrity`, `secrets-policy`
+**Path-scoped:** `nix-tool-policy`, `nix-package-placement`, `ci-cd-policy`, `config-secrets`, `bifrost-routing`
 
 ## On-Demand Standards (Plugins)
 
@@ -132,15 +95,11 @@ Rules are sourced from `agentsmd/rules/` via `.claude/rules/`.
 
 ## Cross-Repo Boundary
 
-This file is the **universal** shared config — it applies to every repo
-that symlinks it as `CLAUDE.md` / `GEMINI.md`.
-Repo-specific or workspace-specific guidance (container rules, log pipelines,
-worktree maps, infra topology) belongs in the per-repo `CLAUDE.md` or in
-`~/git/CLAUDE.md`, **never here**.
+Universal config — import into per-repo `CLAUDE.md` via `@AGENTS.md`. Repo-specific guidance belongs in the per-repo `CLAUDE.md` or `~/git/CLAUDE.md`.
 
 ## Related Files
 
-- `agentsmd/rules/` — auto-loaded rules (sourced via `.claude/rules` symlink)
+- `agentsmd/rules/` — auto-loaded rules
 - `agentsmd/workflows/` — 5-step development workflow
-- `agentsmd/permissions/` — permission framework (allow / ask / deny)
-- [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins) — plugin source
+- `agentsmd/permissions/` — permission framework
+- [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
-AGENTS.md
+# AI Agents Configuration
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

Add a new "Scope Boundary" rule clarifying that Claude should always implement one-shot local solutions within this repo, mention upstream bugs as FYI, never file issues or PRs to external projects, and use GitHub issues (not Claude Code TODOs) for persistent tracking needs.

Trim AGENTS.md from 147 to approximately 113 lines by condensing prose without dropping any guidance or rules.

Replace CLAUDE.md symlink with a real file using the canonical @AGENTS.md import pattern per Claude Code docs.

## Changes

AGENTS.md:
- Added "Scope Boundary" section with guidance on local solutions vs. upstream issues
- Condensed No Scripts intro, Mandatory Search prose, 10-Line Gate section, Orchestrator Role, Output Format, Model Routing intro, Auto-Loaded Rules, Cross-Repo Boundary, and Related Files
- Restored verb in intro sentence ("are delivered via")
- Corrected heredoc and continuation line counting rules in the 10-Line Gate section
- Restored awesome-* lists to tier 4 (removed during initial trimming)
- Added (tool found/not found, reason) format requirement to search log
- Added rejection of "n/a" as placeholder in search logs

CLAUDE.md:
- Converted from symlink (-> AGENTS.md) to a real file with a heading and @AGENTS.md import
- Implements official Claude Code import pattern per docs

soul.md:
- Changed reference style to document-name-only (no full path, no section marker)

## Test plan

- Verify Claude loads AGENTS.md content in a new session within this repo
- Confirm all rules are present vs. the previous 147-line version
- Verify the scope boundary guidance is clear and actionable
- Check that other repos with symlinked CLAUDE.md still work