### PR TITLE
chore: remove deprecated GH_ACTION_JACOBPEVANS_APP_ID from workflow callers

### DIFF
--- a/.github/workflows/copilot-ci-fix.yml
+++ b/.github/workflows/copilot-ci-fix.yml
@@ -93,7 +93,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Submit fix review

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -29,5 +29,4 @@ jobs:
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,5 +13,4 @@ jobs:
       pull-requests: write
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Removes `GH_ACTION_JACOBPEVANS_APP_ID` from `secrets:` passthrough in release-please and gh-aw-pin-refresh callers
- Migrates copilot-ci-fix.yml: `app-id:` → `client-id: ${{ vars.GH_APP_CLIENT_ID }}`
- Central reusable workflows now read GitHub App Client ID directly from vars (no secrets passthrough needed)

**Merge order:** secrets-sync#74 → .github#268 → consumer PRs

## Changes
- .github/workflows/gh-aw-pin-refresh.yml
- .github/workflows/release-please.yml
- .github/workflows/copilot-ci-fix.yml

## Test Plan
- [ ] Verify .github#268 merged first
- [ ] Verify `GH_APP_CLIENT_ID` is available in vars on this repo (synced by secrets-sync)
- [ ] Trigger release-please workflow — confirm no deprecation warnings in run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)