### PR TITLE
chore(rules): make no-scripts rule unmissable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,38 +14,29 @@ Scripts MUST be standalone files with a proper extension (`.sh`, `.py`,
 `.claude/hooks/`, `tests/`, or `plugins/<name>/hooks/` directories. **Never
 comingled in non-script files. No exceptions.**
 
-### What counts as an inline script (BANNED)
+### Inline scripts (BANNED)
 
-These are scripts even when they don't end in `.sh` — all forbidden in
-non-script files:
+Scripts even when they don't end in `.sh` — all forbidden in non-script files:
 
-- YAML `run:` blocks with logic — `if`, `for`, `while`, `case`, multi-step
-  retry, or more than 3 lines of shell.
-- Markdown code blocks intended for copy-paste-execute, when they contain
-  logic.
-- `Bash` tool commands with embedded multi-line control flow
-  (`while ...; do ...; done`, `for x in ...; do ...; done`,
-  `if [[ ... ]]; then ...; fi`) inside a single `command` string.
-- Heredoc payloads (`<<EOF`, `<<'EOF'`, `<<-EOF`) feeding logic to a target
-  — `bash <<EOF`, `python <<EOF`, `cat <<EOF | sh`.
-- Command-substitution heredocs smuggling a script body into a one-liner:
-  `git commit -m "$(cat <<'EOF' ... EOF)"`,
-  `gh pr create --body "$(cat <<'EOF' ... EOF)"` *when the body is
-  generated logic* (pre-written prose body is fine — see Allowed below).
+- YAML `run:` with logic (`if`/`for`/`while`/`case`, retry chains, 3+ lines).
+- Markdown copy-paste-execute blocks containing logic.
+- Multi-line control flow in a single Bash command (`while ...; do ...; done`,
+  `for ...`, `if ...; then ...`).
+- Heredoc payloads carrying logic — `bash <<EOF`, `python <<EOF`,
+  `cat <<EOF | sh`, or `git commit -m "$(cat <<'EOF' ... EOF)"` with
+  generated content (pre-written prose bodies are fine — see Allowed).
 - `python -c '...'`, `node -e '...'`, `perl -e '...'`, `ruby -e '...'`,
-  `sh -c '<multiline>'`, `bash -c '<multiline>'`.
+  multi-line `sh -c` / `bash -c`.
 
-### What is allowed (not a script; rule does not trigger)
+### Allowed (not a script)
 
-- Single-line shell commands and pipelines, however clever
+- Single-line shell pipelines, however clever
   (`gh api ... | jq -r ... | xargs -I{} gh api --method DELETE ...`).
-- One-line heredocs feeding **pre-existing prose** to a CLI:
-  `gh pr create --body "$(cat <<'EOF' ... EOF)"` where the body is the PR
-  description text the user will see, not generated logic.
-- YAML `run:` blocks of 1–3 lines with no control flow (`run: pnpm install`,
-  `run: terraform validate`).
-- Inline shell inside a single `Bash` call WITHOUT control flow keywords
-  AND WITHOUT newlines (`a && b && c` is fine; multi-line is not).
+- One-line heredocs feeding **pre-existing prose** to a CLI
+  (e.g., `gh pr create --body "$(cat <<'EOF' ... EOF)"` with a static body).
+- YAML `run:` of 1–3 lines without control flow (`run: pnpm install`).
+- Single Bash commands without control-flow keywords or newlines
+  (`a && b && c` is fine; multi-line is not).
 
 ### Mandatory four-tier search (before any new dedicated script file)
 
@@ -64,19 +55,16 @@ rows or "n/a" are rejected.
 
 ### The 10-line gate (only after search is empty)
 
-When a dedicated script file is genuinely required:
+For a genuinely required dedicated script file:
 
-- Under 10 non-comment lines AND search empty: auto-approved.
-  (Counting: shebang counts; every code line, heredoc/multi-line-string
-  line, and continuation line counts; blank and pure-comment lines don't;
-  no semicolon-stuffing.)
-- 10+ non-comment lines: ASK the user and wait for an unambiguous yes.
+- <10 non-comment lines AND search empty: auto-approved.
+  (Code, shebang, heredoc, continuation lines all count; blank and
+  pure-comment lines don't; no semicolon-stuffing.)
+- 10+ non-comment lines: ASK and wait for an unambiguous yes.
 
-Hook blocks are TERMINAL DENIALS. When a hook blocks an action, stop and
-reconsider — do not look for a workaround.
+Hook blocks are TERMINAL DENIALS — stop and reconsider, no workarounds.
 
-See `agentsmd/rules/no-scripts.md` for full rationale, worked examples,
-and the dedicated-directory allow-list.
+See `agentsmd/rules/no-scripts.md` for worked examples and the directory allow-list.
 
 ## Starting Any Change
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,82 @@
 
 Commands, skills, agents, and hooks are delivered via [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins).
 
+## No Scripts — Iron Law
+
+**A custom script is the LAST RESORT. Search first; script only when every
+tier comes up empty AND the user explicitly approves.**
+
+### Scripts must be dedicated files
+
+Scripts MUST be standalone files with a proper extension (`.sh`, `.py`,
+`.ts`, `.js`, `.rb`, `.pl`) under one of: `scripts/`, `.github/scripts/`,
+`.claude/hooks/`, `tests/`, or plugin `hooks/` directories. **Never
+comingled in non-script files. No exceptions.**
+
+### What counts as an inline script (BANNED)
+
+These are scripts even when they don't end in `.sh` — all forbidden in
+non-script files:
+
+- YAML `run:` blocks with logic — `if`, `for`, `while`, `case`, multi-step
+  retry, or more than 3 lines of shell.
+- Markdown code blocks intended for copy-paste-execute, when they contain
+  logic.
+- `Bash` tool commands with embedded multi-line control flow
+  (`while ...; do ...; done`, `for x in ...; do ...; done`,
+  `if [[ ... ]]; then ...; fi`) inside a single `command` string.
+- Heredoc payloads (`<<EOF`, `<<'EOF'`, `<<-EOF`) feeding logic to a target
+  — `bash <<EOF`, `python <<EOF`, `cat <<EOF | sh`.
+- Command-substitution heredocs smuggling a script body into a one-liner:
+  `git commit -m "$(cat <<'EOF' ... EOF)"`,
+  `gh pr create --body "$(cat <<'EOF' ... EOF)"` *when the body is
+  generated logic* (pre-written prose body is fine — see Allowed below).
+- `python -c '...'`, `node -e '...'`, `perl -e '...'`, `ruby -e '...'`,
+  `sh -c '<multiline>'`, `bash -c '<multiline>'`.
+
+### What is allowed (not a script; rule does not trigger)
+
+- Single-line shell commands and pipelines, however clever
+  (`gh api ... | jq -r ... | xargs -I{} gh api --method DELETE ...`).
+- One-line heredocs feeding **pre-existing prose** to a CLI:
+  `gh pr create --body "$(cat <<'EOF' ... EOF)"` where the body is the PR
+  description text the user will see, not generated logic.
+- YAML `run:` blocks of 1–3 lines with no control flow (`run: pnpm install`,
+  `run: terraform validate`).
+- Inline shell inside a single `Bash` call WITHOUT control flow keywords
+  AND WITHOUT newlines (`a && b && c` is fine; multi-line is not).
+
+### Mandatory four-tier search (before any new dedicated script file)
+
+Search and document each tier:
+
+1. **Native CLIs / builtins** — `jq`, `gh`, `git`, `curl`, system utilities
+2. **Ecosystem primitives** — Ansible modules, Terraform resources, Nix
+   functions, marketplace Actions, pre-commit hooks
+3. **Third-party packaged tools** — Homebrew, apt, pip, npm, cargo
+4. **Popular community solutions** — well-starred GitHub projects, official
+   plugins, awesome-* lists
+
+Use a cheap model via Bifrost (`listmodels`) + Context7; include a
+one-line-per-tier search log (tool → found / not found, reason) — empty
+rows or "n/a" are rejected.
+
+### The 10-line gate (only after search is empty)
+
+When a dedicated script file is genuinely required:
+
+- Under 10 non-comment lines AND search empty: auto-approved.
+  (Counting: shebang counts; every code line, heredoc/multi-line-string
+  line, and continuation line counts; blank and pure-comment lines don't;
+  no semicolon-stuffing.)
+- 10+ non-comment lines: ASK the user and wait for an unambiguous yes.
+
+Hook blocks are TERMINAL DENIALS. When a hook blocks an action, stop and
+reconsider — do not look for a workaround.
+
+See `agentsmd/rules/no-scripts.md` for full rationale, worked examples,
+and the dedicated-directory allow-list.
+
 ## Starting Any Change
 
 Run `/refresh-repo`, then create a worktree at `~/git/<repo>/<type>/<name>`
@@ -16,28 +92,6 @@ upstream projects outside the user's organizations.
 If a true one-shot is not achievable, recommend creating GitHub issues in the
 user's own repos for persistent tracking — do not use Claude Code's internal
 TODO system as a substitute for durable issue tracking.
-
-## No Scripts — Iron Law
-
-**A custom script is the LAST RESORT. Search first, script only when every tier comes up empty AND the user explicitly approves.**
-
-### Mandatory Search (every tier, every time)
-
-Before any script or inline code with logic, search and document each tier:
-
-1. **Native CLIs / builtins** — `jq`, `gh`, `git`, `curl`, system utilities
-2. **Ecosystem primitives** — Ansible modules, Terraform resources, Nix functions, marketplace Actions, pre-commit hooks
-3. **Third-party packaged tools** — Homebrew, apt, pip, npm, cargo
-4. **Popular community solutions** — well-starred GitHub projects, official plugins, awesome-* lists
-
-Use a cheap model via Bifrost (`listmodels`) + Context7; include a one-line-per-tier search log
-(tool → found/not found, reason) — empty rows or "n/a" are rejected.
-
-### The 10-Line Gate
-
-Auto-approval only when search is empty AND the script is under 10 non-comment lines
-(shebang, code, heredoc/multi-line-string, and continuation lines count; blank and pure-comment lines don't; no semicolon-stuffing).
-At 10+, ASK and wait for an unambiguous yes. Hook blocks are TERMINAL DENIALS.
 
 ## Orchestrator Role
 
@@ -82,7 +136,7 @@ Bifrost routing details in the `bifrost-routing` rule (lazy-loaded).
 
 Sources: `agentsmd/rules/` via `.claude/rules/`.
 
-**Universal:** `tool-use`, `soul`, `skill-execution-integrity`, `secrets-policy`
+**Universal:** `tool-use`, `soul`, `skill-execution-integrity`, `secrets-policy`, `no-scripts`
 **Path-scoped:** `nix-tool-policy`, `nix-package-placement`, `ci-cd-policy`, `config-secrets`, `bifrost-routing`
 
 ## On-Demand Standards (Plugins)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,13 @@ Commands, skills, agents, and hooks are delivered via [JacobPEvans/claude-code-p
 ## No Scripts — Iron Law
 
 **A custom script is the LAST RESORT. Search first; script only when every
-tier comes up empty AND the user explicitly approves.**
+tier comes up empty AND approval is granted (see the 10-line gate below).**
 
 ### Scripts must be dedicated files
 
 Scripts MUST be standalone files with a proper extension (`.sh`, `.py`,
 `.ts`, `.js`, `.rb`, `.pl`) under one of: `scripts/`, `.github/scripts/`,
-`.claude/hooks/`, `tests/`, or plugin `hooks/` directories. **Never
+`.claude/hooks/`, `tests/`, or `plugins/<name>/hooks/` directories. **Never
 comingled in non-script files. No exceptions.**
 
 ### What counts as an inline script (BANNED)
@@ -59,7 +59,7 @@ Search and document each tier:
    plugins, awesome-* lists
 
 Use a cheap model via Bifrost (`listmodels`) + Context7; include a
-one-line-per-tier search log (tool → found / not found, reason) — empty
+one-line-per-tier search log (`<Tier>: <tool> - <found / not found>, <reason>`) — empty
 rows or "n/a" are rejected.
 
 ### The 10-line gate (only after search is empty)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,67 +4,34 @@ Commands, skills, agents, and hooks are delivered via [JacobPEvans/claude-code-p
 
 ## No Scripts — Iron Law
 
-**A custom script is the LAST RESORT. Search first; script only when every
-tier comes up empty AND approval is granted (see the 10-line gate below).**
+**Custom scripts are LAST RESORT.** Search first; script only when every tier comes up empty AND the 10-line gate passes.
 
-### Scripts must be dedicated files
+Scripts MUST live in dedicated files (`.sh`, `.py`, `.ts`, `.js`, `.rb`, `.pl`) under
+`scripts/`, `.github/scripts/`, `.claude/hooks/`, `tests/`, or `plugins/<name>/hooks/`.
+**Never inlined in non-script files.**
 
-Scripts MUST be standalone files with a proper extension (`.sh`, `.py`,
-`.ts`, `.js`, `.rb`, `.pl`) under one of: `scripts/`, `.github/scripts/`,
-`.claude/hooks/`, `tests/`, or `plugins/<name>/hooks/` directories. **Never
-comingled in non-script files. No exceptions.**
+**Banned in non-script files** (still scripts without `.sh`):
 
-### Inline scripts (BANNED)
+- YAML `run:` with control flow (`if`/`for`/`while`/`case`) or 3+ lines.
+- Multi-line control flow in a single Bash command.
+- Heredocs carrying logic (`bash <<EOF`, `python <<EOF`, generated `git commit` bodies).
+- Inline interpreters: `python -c`, `node -e`, `perl -e`, `ruby -e`, multi-line `bash -c`.
+- Markdown copy-paste-execute blocks with logic.
 
-Scripts even when they don't end in `.sh` — all forbidden in non-script files:
+**Allowed**: single-line pipelines (`|`/`&&`/`xargs`), 1–3 line YAML `run:` without control flow, one-line heredocs feeding pre-written prose (e.g., static PR bodies).
 
-- YAML `run:` with logic (`if`/`for`/`while`/`case`, retry chains, 3+ lines).
-- Markdown copy-paste-execute blocks containing logic.
-- Multi-line control flow in a single Bash command (`while ...; do ...; done`,
-  `for ...`, `if ...; then ...`).
-- Heredoc payloads carrying logic — `bash <<EOF`, `python <<EOF`,
-  `cat <<EOF | sh`, or `git commit -m "$(cat <<'EOF' ... EOF)"` with
-  generated content (pre-written prose bodies are fine — see Allowed).
-- `python -c '...'`, `node -e '...'`, `perl -e '...'`, `ruby -e '...'`,
-  multi-line `sh -c` / `bash -c`.
+**Four-tier search** before any new script file — log one line per tier (`<Tier>: <tool> - <found/not found>, <reason>`); empty rows rejected:
 
-### Allowed (not a script)
+1. Native CLIs / builtins (`jq`, `gh`, `git`, `curl`)
+2. Ecosystem primitives (Ansible modules, Terraform resources, marketplace Actions, pre-commit)
+3. Third-party packaged tools (Homebrew, apt, pip, npm, cargo)
+4. Popular community solutions (GitHub projects, official plugins, awesome-* lists)
 
-- Single-line shell pipelines, however clever
-  (`gh api ... | jq -r ... | xargs -I{} gh api --method DELETE ...`).
-- One-line heredocs feeding **pre-existing prose** to a CLI
-  (e.g., `gh pr create --body "$(cat <<'EOF' ... EOF)"` with a static body).
-- YAML `run:` of 1–3 lines without control flow (`run: pnpm install`).
-- Single Bash commands without control-flow keywords or newlines
-  (`a && b && c` is fine; multi-line is not).
+**10-line gate** (after empty search): <10 non-comment lines auto-approved; 10+ requires
+explicit user yes. Code/shebang/heredoc/continuation count; blanks and comments don't; no
+semicolon-stuffing.
 
-### Mandatory four-tier search (before any new dedicated script file)
-
-Search and document each tier:
-
-1. **Native CLIs / builtins** — `jq`, `gh`, `git`, `curl`, system utilities
-2. **Ecosystem primitives** — Ansible modules, Terraform resources, Nix
-   functions, marketplace Actions, pre-commit hooks
-3. **Third-party packaged tools** — Homebrew, apt, pip, npm, cargo
-4. **Popular community solutions** — well-starred GitHub projects, official
-   plugins, awesome-* lists
-
-Use a cheap model via Bifrost (`listmodels`) + Context7; include a
-one-line-per-tier search log (`<Tier>: <tool> - <found / not found>, <reason>`) — empty
-rows or "n/a" are rejected.
-
-### The 10-line gate (only after search is empty)
-
-For a genuinely required dedicated script file:
-
-- <10 non-comment lines AND search empty: auto-approved.
-  (Code, shebang, heredoc, continuation lines all count; blank and
-  pure-comment lines don't; no semicolon-stuffing.)
-- 10+ non-comment lines: ASK and wait for an unambiguous yes.
-
-Hook blocks are TERMINAL DENIALS — stop and reconsider, no workarounds.
-
-See `agentsmd/rules/no-scripts.md` for worked examples and the directory allow-list.
+Hook blocks are TERMINAL DENIALS. See `agentsmd/rules/no-scripts.md` for worked examples.
 
 ## Starting Any Change
 

--- a/agentsmd/rules/no-scripts.md
+++ b/agentsmd/rules/no-scripts.md
@@ -4,34 +4,21 @@ description: Scripts MUST live in dedicated script files; never comingled in YAM
 
 # No Scripts — Detailed Rule
 
-The short rule lives in `AGENTS.md` ("No Scripts — Iron Law"). This file
-holds the full rationale, expanded examples, and the dedicated-directory
-allow-list.
+Companion to the iron law in `AGENTS.md`: rationale, worked examples, allow-list.
 
 ## Why this rule exists
 
-Native CLIs and ecosystem primitives are better-maintained than anything
-Claude (or you) would write fresh. They have tests, releases, maintainers,
-documentation that users can read and link to, and behavior that doesn't
-drift between sessions.
-
-Scripts written inline have none of that. They are invisible to linters,
-test runners, and code review when comingled in non-script files (YAML
-workflows, Markdown docs, Bash one-liners, heredocs). They rot the moment
-they're committed and cargo-cult themselves into the next session's pattern.
-
-When a native solution exists, use it. When one doesn't, the four-tier
-search documents *why* the script must exist. The 10-line gate keeps the
-script small enough to read in one sitting. The dedicated-directory
-allow-list keeps the script visible to tooling.
+Native CLIs are better-maintained than anything you'd write fresh — tests,
+releases, docs, stable behavior. Inline scripts have none of that, are
+invisible to linters and review when buried in YAML / Markdown / heredocs,
+and rot on contact. Use native tools first. Document why if you can't.
 
 ## What counts as a "script"
 
-A script is anything with logic — conditionals, loops, branching,
-multi-step state. The container doesn't matter. A 30-line `for` loop
-embedded in a YAML `run:` block is a script. A 50-line `bash` heredoc
-piped into `git commit -m` is a script. Both must move to a dedicated
-file or — better — be replaced with native tools.
+Anything with logic — conditionals, loops, branching, multi-step state. The
+container doesn't matter: a 30-line `for` loop in a YAML `run:` block is a
+script; so is a 50-line `bash` heredoc fed to `git commit -m`. Move them
+to a dedicated file or replace with native tools.
 
 ### Banned (with worked examples)
 
@@ -56,7 +43,7 @@ Right (extract):
   run: .github/scripts/merge-if-quiet.sh
 ```
 
-Or better (native composition):
+Or native composition:
 
 ```yaml
 - uses: peter-evans/enable-pull-request-automerge@v3
@@ -75,7 +62,7 @@ while IFS= read -r branch; do
 done < /tmp/branches.txt
 ```
 
-Right (native):
+Right:
 
 ```text
 gh api repos/x/y/branches --paginate --jq '.[].name' \
@@ -89,17 +76,12 @@ Wrong:
 ```text
 git commit -m "$(cat <<'EOF'
 $(if [[ $(date +%u) == 5 ]]; then echo "Friday deploy"; else echo "Standard"; fi)
-
 $(git log --oneline | head -5)
 EOF
 )"
 ```
 
-Right (compose first, commit second; or just write a one-line message):
-
-```text
-git commit -m "feat: standard release"
-```
+Right: `git commit -m "feat: standard release"`
 
 #### Inline interpreters
 
@@ -107,22 +89,16 @@ Wrong: `python -c "import json; print(json.load(open('x.json'))['key'])"`
 
 Right: `jq -r .key x.json`
 
-### Allowed (not a script; rule does not trigger)
+### Allowed (not a script)
 
-- **Single-line pipelines.** Compose with `|`, `&&`, `||`, `xargs` — even
-  long pipelines are fine if they're a single line and lean on native CLIs.
-- **One-line heredocs feeding pre-existing prose.** A PR body that is
-  pre-written prose, fed via heredoc to `gh pr create --body`, is fine.
-  The heredoc is a string-passing mechanism, not a script.
-- **Short YAML `run:` blocks** without control flow: `run: pnpm install`,
-  `run: terraform validate`, `run: pnpm install && pnpm build`.
-- **Single Bash commands with `&&`/`||`** chaining, no control-flow
-  keywords, no newlines.
+- Single-line pipelines, however long. `|`, `&&`, `||`, `xargs` chains are fine.
+- One-line heredocs feeding **pre-existing prose** to a CLI (e.g.,
+  `gh pr create --body "$(cat <<'EOF' ... EOF)"` with a static body).
+- YAML `run:` of 1–3 lines without control flow (`run: pnpm install`).
+- Single Bash commands without control-flow keywords or newlines
+  (`a && b && c` is fine).
 
 ## Allowed dedicated-script directories
-
-When a script is genuinely required (search empty, four-tier log clean,
-under 10 lines or user-approved), it must live in one of:
 
 | Directory | Purpose |
 | --- | --- |
@@ -132,25 +108,12 @@ under 10 lines or user-approved), it must live in one of:
 | `tests/` | Test fixtures and runners |
 | `plugins/<name>/hooks/` | Plugin-supplied hook scripts |
 
-The script must have a proper extension (`.sh`, `.py`, `.ts`, `.js`,
-`.rb`, `.pl`) and a shebang on the first line. No extensionless script
-files; no scripts in arbitrary repo paths.
+Proper extension (`.sh`, `.py`, `.ts`, `.js`, `.rb`, `.pl`) and a shebang
+are required. No extensionless scripts; no scripts in arbitrary paths.
 
-## The four-tier search (mandatory)
+## Four-tier search
 
-Before any new dedicated script file, search and log each tier:
-
-1. **Native CLIs / builtins** — `jq`, `gh`, `git`, `curl`, system utilities
-2. **Ecosystem primitives** — Ansible modules, Terraform resources, Nix
-   functions, marketplace Actions, pre-commit hooks
-3. **Third-party packaged tools** — Homebrew, apt, pip, npm, cargo
-4. **Popular community solutions** — well-starred GitHub projects, official
-   plugins, awesome-* lists
-
-Format: one line per tier. `<Tier Name>: <tool searched> - <found / not found>, <reason>`.
-Empty rows or "n/a" are rejected.
-
-Worked example:
+Tiers and the 10-line gate live in `AGENTS.md`. Worked example log:
 
 ```text
 Native CLIs: gh pr merge --auto - found, but lacks quiet-window logic
@@ -159,27 +122,9 @@ Third-party packaged tools: cargo-release - not found, doesn't apply
 Popular community solutions: github.com/.../release-please-action - found, but no quiet-window
 ```
 
-## The 10-line gate
+## When blocked
 
-Only applies after the four-tier search comes up empty.
-
-- Under 10 non-comment lines: auto-approved.
-- 10+ non-comment lines: ASK the user and wait for an unambiguous yes.
-
-Counting: shebang counts; every code line, heredoc/multi-line-string
-line, and continuation line counts; blank and pure-comment lines don't;
-no semicolon-stuffing.
-
-## What to do when blocked
-
-If a hook or permission rule blocks a script-related action:
-
-1. **Stop.** Do not retry. Do not route around the block via a different
-   tool (e.g., do not switch from `Write` to `Bash` to bypass).
-2. **Reconsider.** Re-run the four-tier search; the right answer is usually
-   a native tool you missed the first pass.
-3. **Ask the user.** Explain what you wanted to do, what was blocked, and
-   what native alternative you considered. The user decides.
-
-Routing around a hook is bad-faith behavior. The hook is the rule — when
-it fires, the rule is telling you to think harder, not to work around it.
+Hook block? Stop. Don't retry, don't switch tools to bypass. Re-run the
+search — there's usually a native option you missed. If still stuck, ask
+the user with what you tried and what got blocked. Routing around a hook
+is bad-faith behavior.

--- a/agentsmd/rules/no-scripts.md
+++ b/agentsmd/rules/no-scripts.md
@@ -1,34 +1,26 @@
 ---
-description: Scripts MUST live in dedicated script files; never comingled in YAML, Markdown, Bash one-liners, or heredocs
+description: Scripts MUST live in dedicated script files; never inlined in YAML, Markdown, Bash one-liners, or heredocs
 ---
 
 # No Scripts — Detailed Rule
 
-Companion to the iron law in `AGENTS.md`: rationale, worked examples, allow-list.
+Companion to `AGENTS.md`: rationale, worked examples, allow-list.
 
-## Why this rule exists
+## Why
 
-Native CLIs are better-maintained than anything you'd write fresh — tests,
-releases, docs, stable behavior. Inline scripts have none of that, are
-invisible to linters and review when buried in YAML / Markdown / heredocs,
-and rot on contact. Use native tools first. Document why if you can't.
+Native CLIs have tests, releases, docs, stable behavior. Inline scripts have
+none of that, hide from linters when buried in YAML/Markdown/heredocs, and
+rot fast. A "script" is anything with logic — conditionals, loops, branching,
+multi-step state — regardless of container.
 
-## What counts as a "script"
+## Worked examples
 
-Anything with logic — conditionals, loops, branching, multi-step state. The
-container doesn't matter: a 30-line `for` loop in a YAML `run:` block is a
-script; so is a 50-line `bash` heredoc fed to `git commit -m`. Move them
-to a dedicated file or replace with native tools.
-
-### Banned (with worked examples)
-
-#### YAML `run:` blocks with logic
+### YAML `run:` with logic
 
 Wrong:
 
 ```yaml
-- name: Merge if quiet window
-  run: |
+- run: |
     for pr in $(gh pr list --json number -q '.[].number'); do
       if [[ $(date +%H) -ge 9 && $(date +%H) -le 17 ]]; then
         gh pr merge "$pr" --squash --auto
@@ -36,23 +28,14 @@ Wrong:
     done
 ```
 
-Right (extract):
+Right — extract, or use a native action:
 
 ```yaml
-- name: Merge if quiet window
-  run: .github/scripts/merge-if-quiet.sh
-```
-
-Or native composition:
-
-```yaml
+- run: .github/scripts/merge-if-quiet.sh
 - uses: peter-evans/enable-pull-request-automerge@v3
-  with:
-    pull-request-number: ${{ github.event.pull_request.number }}
-    merge-method: squash
 ```
 
-#### Bash with multi-line control flow
+### Bash with multi-line control flow
 
 Wrong:
 
@@ -69,62 +52,41 @@ gh api repos/x/y/branches --paginate --jq '.[].name' \
   | xargs -I{} gh api --method DELETE repos/x/y/git/refs/heads/{}
 ```
 
-#### Heredoc smuggling logic
+### Heredoc smuggling logic
 
-Wrong:
-
-```text
-git commit -m "$(cat <<'EOF'
-$(if [[ $(date +%u) == 5 ]]; then echo "Friday deploy"; else echo "Standard"; fi)
-$(git log --oneline | head -5)
-EOF
-)"
-```
+Wrong: `git commit -m "$(cat <<'EOF' ... $(if ...) ... EOF)"`
 
 Right: `git commit -m "feat: standard release"`
 
-#### Inline interpreters
+### Inline interpreters
 
 Wrong: `python -c "import json; print(json.load(open('x.json'))['key'])"`
 
 Right: `jq -r .key x.json`
 
-### Allowed (not a script)
-
-- Single-line pipelines, however long. `|`, `&&`, `||`, `xargs` chains are fine.
-- One-line heredocs feeding **pre-existing prose** to a CLI (e.g.,
-  `gh pr create --body "$(cat <<'EOF' ... EOF)"` with a static body).
-- YAML `run:` of 1–3 lines without control flow (`run: pnpm install`).
-- Single Bash commands without control-flow keywords or newlines
-  (`a && b && c` is fine).
-
 ## Allowed dedicated-script directories
 
 | Directory | Purpose |
 | --- | --- |
-| `scripts/` | Project-level utility scripts |
-| `.github/scripts/` | Scripts called from GitHub Actions workflows |
+| `scripts/` | Project utility scripts |
+| `.github/scripts/` | Called from Actions workflows |
 | `.claude/hooks/` | Claude Code hook scripts |
 | `tests/` | Test fixtures and runners |
 | `plugins/<name>/hooks/` | Plugin-supplied hook scripts |
 
-Proper extension (`.sh`, `.py`, `.ts`, `.js`, `.rb`, `.pl`) and a shebang
-are required. No extensionless scripts; no scripts in arbitrary paths.
+Proper extension (`.sh`, `.py`, `.ts`, `.js`, `.rb`, `.pl`) and shebang required.
 
-## Four-tier search
-
-Tiers and the 10-line gate live in `AGENTS.md`. Worked example log:
+## Search log example
 
 ```text
 Native CLIs: gh pr merge --auto - found, but lacks quiet-window logic
-Ecosystem primitives: peter-evans/enable-pull-request-automerge@v3 - found, but no time-of-day gate
+Ecosystem primitives: peter-evans/enable-pull-request-automerge@v3 - found, no time-of-day gate
 Third-party packaged tools: cargo-release - not found, doesn't apply
-Popular community solutions: github.com/.../release-please-action - found, but no quiet-window
+Popular community solutions: release-please-action - found, no quiet-window
 ```
 
 ## When blocked
 
-Hook block? Stop. Don't retry, don't switch tools to bypass. Re-run the
-search — there's usually a native option you missed. If still stuck, ask
-the user with what you tried and what got blocked. Routing around a hook
-is bad-faith behavior.
+Stop. Don't switch tools to bypass — re-run the search; usually a native
+option was missed. If still stuck, ask the user. Routing around a hook is
+bad-faith.

--- a/agentsmd/rules/no-scripts.md
+++ b/agentsmd/rules/no-scripts.md
@@ -1,0 +1,185 @@
+---
+description: Scripts MUST live in dedicated script files; never comingled in YAML, Markdown, Bash one-liners, or heredocs
+---
+
+# No Scripts — Detailed Rule
+
+The short rule lives in `AGENTS.md` ("No Scripts — Iron Law"). This file
+holds the full rationale, expanded examples, and the dedicated-directory
+allow-list.
+
+## Why this rule exists
+
+Native CLIs and ecosystem primitives are better-maintained than anything
+Claude (or you) would write fresh. They have tests, releases, maintainers,
+documentation that users can read and link to, and behavior that doesn't
+drift between sessions.
+
+Scripts written inline have none of that. They are invisible to linters,
+test runners, and code review when comingled in non-script files (YAML
+workflows, Markdown docs, Bash one-liners, heredocs). They rot the moment
+they're committed and cargo-cult themselves into the next session's pattern.
+
+When a native solution exists, use it. When one doesn't, the four-tier
+search documents *why* the script must exist. The 10-line gate keeps the
+script small enough to read in one sitting. The dedicated-directory
+allow-list keeps the script visible to tooling.
+
+## What counts as a "script"
+
+A script is anything with logic — conditionals, loops, branching,
+multi-step state. The container doesn't matter. A 30-line `for` loop
+embedded in a YAML `run:` block is a script. A 50-line `bash` heredoc
+piped into `git commit -m` is a script. Both must move to a dedicated
+file or — better — be replaced with native tools.
+
+### Banned (with worked examples)
+
+#### YAML `run:` blocks with logic
+
+Wrong:
+
+```yaml
+- name: Merge if quiet window
+  run: |
+    for pr in $(gh pr list --json number -q '.[].number'); do
+      if [[ $(date +%H) -ge 9 && $(date +%H) -le 17 ]]; then
+        gh pr merge "$pr" --squash --auto
+      fi
+    done
+```
+
+Right (extract):
+
+```yaml
+- name: Merge if quiet window
+  run: .github/scripts/merge-if-quiet.sh
+```
+
+Or better (native composition):
+
+```yaml
+- uses: peter-evans/enable-pull-request-automerge@v3
+  with:
+    pull-request-number: ${{ github.event.pull_request.number }}
+    merge-method: squash
+```
+
+#### Bash with multi-line control flow
+
+Wrong:
+
+```text
+while IFS= read -r branch; do
+  gh api repos/x/y/git/refs/heads/$branch -X DELETE
+done < /tmp/branches.txt
+```
+
+Right (native):
+
+```text
+gh api repos/x/y/branches --paginate --jq '.[].name' \
+  | xargs -I{} gh api --method DELETE repos/x/y/git/refs/heads/{}
+```
+
+#### Heredoc smuggling logic
+
+Wrong:
+
+```text
+git commit -m "$(cat <<'EOF'
+$(if [[ $(date +%u) == 5 ]]; then echo "Friday deploy"; else echo "Standard"; fi)
+
+$(git log --oneline | head -5)
+EOF
+)"
+```
+
+Right (compose first, commit second; or just write a one-line message):
+
+```text
+git commit -m "feat: standard release"
+```
+
+#### Inline interpreters
+
+Wrong: `python -c "import json; print(json.load(open('x.json'))['key'])"`
+
+Right: `jq -r .key x.json`
+
+### Allowed (not a script; rule does not trigger)
+
+- **Single-line pipelines.** Compose with `|`, `&&`, `||`, `xargs` — even
+  long pipelines are fine if they're a single line and lean on native CLIs.
+- **One-line heredocs feeding pre-existing prose.** A PR body that is
+  pre-written prose, fed via heredoc to `gh pr create --body`, is fine.
+  The heredoc is a string-passing mechanism, not a script.
+- **Short YAML `run:` blocks** without control flow: `run: pnpm install`,
+  `run: terraform validate`, `run: pnpm install && pnpm build`.
+- **Single Bash commands with `&&`/`||`** chaining, no control-flow
+  keywords, no newlines.
+
+## Allowed dedicated-script directories
+
+When a script is genuinely required (search empty, four-tier log clean,
+under 10 lines or user-approved), it must live in one of:
+
+| Directory | Purpose |
+| --- | --- |
+| `scripts/` | Project-level utility scripts |
+| `.github/scripts/` | Scripts called from GitHub Actions workflows |
+| `.claude/hooks/` | Claude Code hook scripts |
+| `tests/` | Test fixtures and runners |
+| `plugins/<name>/hooks/` | Plugin-supplied hook scripts |
+
+The script must have a proper extension (`.sh`, `.py`, `.ts`, `.js`,
+`.rb`, `.pl`) and a shebang on the first line. No extensionless script
+files; no scripts in arbitrary repo paths.
+
+## The four-tier search (mandatory)
+
+Before any new dedicated script file, search and log each tier:
+
+1. **Native CLIs / builtins** — `jq`, `gh`, `git`, `curl`, system utilities
+2. **Ecosystem primitives** — Ansible modules, Terraform resources, Nix
+   functions, marketplace Actions, pre-commit hooks
+3. **Third-party packaged tools** — Homebrew, apt, pip, npm, cargo
+4. **Popular community solutions** — well-starred GitHub projects, official
+   plugins, awesome-* lists
+
+Format: one line per tier. `tool searched → found / not found, reason`.
+Empty rows or "n/a" are rejected.
+
+Worked example:
+
+```text
+Native CLIs: gh pr merge --auto - found, but lacks quiet-window logic
+Ecosystem primitives: peter-evans/enable-pull-request-automerge@v3 - found, but no time-of-day gate
+Third-party packaged tools: cargo-release - not found, doesn't apply
+Popular community solutions: github.com/.../release-please-action - found, but no quiet-window
+```
+
+## The 10-line gate
+
+Only applies after the four-tier search comes up empty.
+
+- Under 10 non-comment lines: auto-approved.
+- 10+ non-comment lines: ASK the user and wait for an unambiguous yes.
+
+Counting: shebang counts; every code line, heredoc/multi-line-string
+line, and continuation line counts; blank and pure-comment lines don't;
+no semicolon-stuffing.
+
+## What to do when blocked
+
+If a hook or permission rule blocks a script-related action:
+
+1. **Stop.** Do not retry. Do not route around the block via a different
+   tool (e.g., do not switch from `Write` to `Bash` to bypass).
+2. **Reconsider.** Re-run the four-tier search; the right answer is usually
+   a native tool you missed the first pass.
+3. **Ask the user.** Explain what you wanted to do, what was blocked, and
+   what native alternative you considered. The user decides.
+
+Routing around a hook is bad-faith behavior. The hook is the rule — when
+it fires, the rule is telling you to think harder, not to work around it.

--- a/agentsmd/rules/no-scripts.md
+++ b/agentsmd/rules/no-scripts.md
@@ -147,7 +147,7 @@ Before any new dedicated script file, search and log each tier:
 4. **Popular community solutions** — well-starred GitHub projects, official
    plugins, awesome-* lists
 
-Format: one line per tier. `tool searched → found / not found, reason`.
+Format: one line per tier. `<Tier Name>: <tool searched> - <found / not found>, <reason>`.
 Empty rows or "n/a" are rejected.
 
 Worked example:

--- a/agentsmd/rules/tool-use.md
+++ b/agentsmd/rules/tool-use.md
@@ -57,10 +57,10 @@ Explore agents are exempt (read-only, no Edit/Write tools).
 Script policy (Required verbatim in every subagent prompt):
 
 - Scripts are LAST RESORT. Search first; script only when every tier comes
-  up empty AND the user explicitly approves.
+  up empty AND approval is granted (see 10-line gate below).
 - Scripts MUST live in dedicated script files (`.sh`, `.py`, `.ts`, `.js`,
   `.rb`, `.pl`) under `scripts/`, `.github/scripts/`, `.claude/hooks/`,
-  `tests/`, or plugin `hooks/` dirs. NEVER comingled in non-script files.
+  `tests/`, or `plugins/<name>/hooks/` dirs. NEVER comingled in non-script files.
 - Inline scripts are forbidden in ALL non-script files: no logic in YAML
   `run:` blocks, no heredoc payloads carrying logic, no multi-line control
   flow inside a single Bash command, no `python -c` / `node -e` / `bash -c`.

--- a/agentsmd/rules/tool-use.md
+++ b/agentsmd/rules/tool-use.md
@@ -56,11 +56,19 @@ Explore agents are exempt (read-only, no Edit/Write tools).
 
 Script policy (Required verbatim in every subagent prompt):
 
-- Scripts are LAST RESORT. See the No Scripts iron law in AGENTS.md.
-- Before writing ANY script, exhaust the four-tier search and log it in
-  your reply. Hook blocks are TERMINAL DENIALS, not fallback menus.
-- Under 10 non-comment lines: auto-approved after empty search log.
+- Scripts are LAST RESORT. Search first; script only when every tier comes
+  up empty AND the user explicitly approves.
+- Scripts MUST live in dedicated script files (`.sh`, `.py`, `.ts`, `.js`,
+  `.rb`, `.pl`) under `scripts/`, `.github/scripts/`, `.claude/hooks/`,
+  `tests/`, or plugin `hooks/` dirs. NEVER comingled in non-script files.
+- Inline scripts are forbidden in ALL non-script files: no logic in YAML
+  `run:` blocks, no heredoc payloads carrying logic, no multi-line control
+  flow inside a single Bash command, no `python -c` / `node -e` / `bash -c`.
+- Before writing ANY new dedicated script file, exhaust the four-tier
+  search and log it in your reply (one line per tier; empty rows rejected).
+- Under 10 non-comment lines AND search empty: auto-approved.
 - 10+ non-comment lines: ASK the user and wait for an unambiguous yes.
+- Hook blocks are TERMINAL DENIALS, not fallback menus.
 
 ## Subagent Type Selection
 

--- a/agentsmd/rules/tool-use.md
+++ b/agentsmd/rules/tool-use.md
@@ -54,21 +54,17 @@ File operations:
 
 Explore agents are exempt (read-only, no Edit/Write tools).
 
-Script policy (Required verbatim in every subagent prompt):
+Script policy (verbatim in every subagent prompt):
 
-- Scripts are LAST RESORT. Search first; script only when every tier comes
-  up empty AND approval is granted (see 10-line gate below).
-- Scripts MUST live in dedicated script files (`.sh`, `.py`, `.ts`, `.js`,
-  `.rb`, `.pl`) under `scripts/`, `.github/scripts/`, `.claude/hooks/`,
-  `tests/`, or `plugins/<name>/hooks/` dirs. NEVER comingled in non-script files.
-- Inline scripts are forbidden in ALL non-script files: no logic in YAML
-  `run:` blocks, no heredoc payloads carrying logic, no multi-line control
-  flow inside a single Bash command, no `python -c` / `node -e` / `bash -c`.
-- Before any new script file, exhaust the four-tier search; log one line
-  per tier in your reply (empty rows rejected).
-- Under 10 non-comment lines AND search empty: auto-approved.
-- 10+ non-comment lines: ASK the user and wait for an unambiguous yes.
-- Hook blocks are TERMINAL DENIALS, not fallback menus.
+- Scripts are LAST RESORT — search first; script only after empty four-tier
+  search log AND 10-line gate.
+- Scripts live in dedicated files (`.sh`/`.py`/`.ts`/`.js`/`.rb`/`.pl`) under
+  `scripts/`, `.github/scripts/`, `.claude/hooks/`, `tests/`, or
+  `plugins/<name>/hooks/`. Never inlined in non-script files.
+- Forbidden inline: YAML `run:` with logic, heredocs carrying logic,
+  multi-line Bash control flow, `python -c` / `node -e` / `bash -c`.
+- <10 non-comment lines + empty search: auto-approved. 10+: ASK and wait for yes.
+- Hook blocks are TERMINAL DENIALS.
 
 ## Subagent Type Selection
 

--- a/agentsmd/rules/tool-use.md
+++ b/agentsmd/rules/tool-use.md
@@ -64,8 +64,8 @@ Script policy (Required verbatim in every subagent prompt):
 - Inline scripts are forbidden in ALL non-script files: no logic in YAML
   `run:` blocks, no heredoc payloads carrying logic, no multi-line control
   flow inside a single Bash command, no `python -c` / `node -e` / `bash -c`.
-- Before writing ANY new dedicated script file, exhaust the four-tier
-  search and log it in your reply (one line per tier; empty rows rejected).
+- Before any new script file, exhaust the four-tier search; log one line
+  per tier in your reply (empty rows rejected).
 - Under 10 non-comment lines AND search empty: auto-approved.
 - 10+ non-comment lines: ASK the user and wait for an unambiguous yes.
 - Hook blocks are TERMINAL DENIALS, not fallback menus.


### PR DESCRIPTION
## Summary

Restructures the No Scripts rule to lead AGENTS.md and explicitly forbids the comingling patterns Claude keeps generating: YAML run blocks with control flow, multi-line Bash control flow in a single command, heredoc payloads carrying logic, and git commit -m patterns that smuggle scripts into prose.

Addresses recent sessions where subagents produced 50+ line shell scripts, 120+ line YAML workflows with embedded logic, and heredoc-fed git commit patterns — all de facto scripts that the previous wording did not explicitly flag and that existing plugin hooks do not fully catch.

## Changes

- AGENTS.md: moved "No Scripts — Iron Law" to the top position (was 4th section). Added explicit ban on script comingling, banned/allowed enumeration with concrete patterns, and reference to the new detailed rule. Universal auto-loaded rules list now includes no-scripts.
- agentsmd/rules/tool-use.md: synced the verbatim Script policy block (lines 57–63) with AGENTS.md prose. This block is injected into every subagent prompt, so divergence here is what lets subagents drift.
- agentsmd/rules/no-scripts.md (new): universal auto-loaded rule with full rationale, wrong/right worked examples for each banned pattern, and a dedicated-script-directory allow-list (scripts/, .github/scripts/, .claude/hooks/, tests/, plugins/<name>/hooks/).

Retained: four-tier search log flow, 10-line auto-approval gate (now scoped to dedicated script files only), "hook blocks are terminal denials" framing.

## Test Plan

- [ ] markdownlint-cli2 and pre-commit hooks pass across the three changed files
- [ ] CI (_token-limits.yml, _validate-instructions.yml, _markdownlint.yml, ci-gate.yml) passes
- [ ] Replay test (post-merge): ask Claude in a fresh session to "design a release-please quiet-window auto-merge workflow" and verify that:
  - Does NOT inline 100+ lines of shell into a YAML run block
  - Does NOT propose git commit -m patterns with heredoc payloads
  - DOES either compose with gh pr merge steps or proposes a dedicated .github/scripts/foo.sh file with a four-tier search log

Related: #599