### PR TITLE
feat(agents): add diagramming practices section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ See soul.md section 4 — no emoji; conventional-commit prefixes for subjects/ti
 
 | Use case | Format | Placement |
 | --- | --- | --- |
-| Inline with Markdown | Fenced ` ```mermaid ``` ` block | Inside the `.md` file |
+| Inline with Markdown | Fenced `mermaid` code block | Inside the `.md` file |
 | Standalone high-level diagram | SVG file | `docs/assets/` |
 | Diagram source | `.mmd` file | `docs/assets/` (alongside SVG) |
 
@@ -180,7 +180,9 @@ Every repository with meaningful architecture must keep current:
 - **Sequence diagrams** — for complex multi-party interactions (auth flows, API chains, CI pipelines)
 - **Component / deployment diagrams** — for infrastructure with non-trivial topology
 
-Inline Mermaid for every architectural doc section. Standalone SVG for top-level overviews linked from README or docs index. Most repos warrant several diagrams — resist collapsing everything into one; a diagram that shows everything shows nothing. Keep all diagrams in sync with code — a stale diagram is worse than none.
+- **Placement**: inline Mermaid per architectural doc section; standalone SVG for top-level overviews linked from README or docs index.
+- **Granularity**: one diagram per distinct concern — a diagram that shows everything shows nothing.
+- **Freshness**: keep all diagrams in sync with code — a stale diagram is worse than none.
 
 ## Model Routing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,41 @@ See the `tool-use` rule.
 
 See soul.md section 4 — no emoji; conventional-commit prefixes for subjects/titles; plain prose everywhere else.
 
+## Diagramming
+
+**Architecture diagrams are required documentation.** A repo with meaningful architecture and no diagram has missing docs.
+
+### Formats
+
+| Use case | Format | Placement |
+| --- | --- | --- |
+| Inline with Markdown | Fenced ` ```mermaid ``` ` block | Inside the `.md` file |
+| Standalone high-level diagram | SVG file | `docs/assets/` |
+| Diagram source | `.mmd` file | `docs/assets/` (alongside SVG) |
+
+GitHub renders fenced `mermaid` blocks natively — no image upload or external service needed.
+Generate SVG from source: `nix run nixpkgs#mermaid-cli -- -i diagram.mmd -o diagram.svg`
+
+### File Placement
+
+| Content | Location |
+| --- | --- |
+| Root conventional docs (README.md, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md) | `/` (repo root) |
+| Additional documentation | `docs/` |
+| Diagram assets (`.mmd` sources, `.svg` outputs, images) | `docs/assets/` |
+
+### What to Maintain
+
+Every repository with meaningful architecture must keep current:
+
+- **System overview** — internal components and their relationships
+- **Cross-repo / ecosystem context** — where this repo fits within a broader system of repos, services, or teams
+- **Primary data flows** — one diagram per major use case (not all flows collapsed into one)
+- **Sequence diagrams** — for complex multi-party interactions (auth flows, API chains, CI pipelines)
+- **Component / deployment diagrams** — for infrastructure with non-trivial topology
+
+Inline Mermaid for every architectural doc section. Standalone SVG for top-level overviews linked from README or docs index. Most repos warrant several diagrams — resist collapsing everything into one; a diagram that shows everything shows nothing. Keep all diagrams in sync with code — a stale diagram is worse than none.
+
 ## Model Routing
 
 Resolve model names at call time via `listmodels`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,40 +149,16 @@ See soul.md section 4 — no emoji; conventional-commit prefixes for subjects/ti
 
 ## Diagramming
 
-**Architecture diagrams are required documentation.** A repo with meaningful architecture and no diagram has missing docs.
+Required for any repo with meaningful architecture; keep in sync with code — stale is worse than none.
 
-### Formats
-
-| Use case | Format | Placement |
-| --- | --- | --- |
-| Inline with Markdown | Fenced `mermaid` code block | Inside the `.md` file |
-| Standalone diagram source | `.mmd` file | `docs/assets/` |
-| Standalone rendered diagram | SVG (generated from `.mmd`) | `docs/assets/` |
-
-GitHub renders fenced `mermaid` blocks natively — no image upload or external service needed.
-Generate SVG from source: `nix run nixpkgs#mermaid-cli -- -i diagram.mmd -o diagram.svg`
-
-### File Placement
-
-| Content | Location |
-| --- | --- |
-| Root conventional docs (README.md, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md) | `/` (repo root) |
-| Additional documentation | `docs/` |
-| Diagram assets (`.mmd` sources, `.svg` outputs, images) | `docs/assets/` |
-
-### What to Maintain
-
-Every repository with meaningful architecture must keep current:
-
-- **System overview** — internal components and their relationships
-- **Cross-repo / ecosystem context** — where this repo fits within a broader system of repos, services, or teams
-- **Primary data flows** — one diagram per major use case (not all flows collapsed into one)
-- **Sequence diagrams** — for complex multi-party interactions (auth flows, API chains, CI pipelines)
-- **Component / deployment diagrams** — for infrastructure with non-trivial topology
-
-- **Placement**: inline Mermaid per architectural doc section; standalone SVG for top-level overviews linked from README or docs index.
-- **Granularity**: one diagram per distinct concern — a diagram that shows everything shows nothing.
-- **Freshness**: keep all diagrams in sync with code — a stale diagram is worse than none.
+- **Format**: inline fenced `mermaid` blocks (GitHub renders natively — no upload); standalone `.mmd` sources in `docs/assets/`.
+  Render: `nix run nixpkgs#mermaid-cli -- -i x.mmd -o x.svg`.
+- **Placement**: conventional docs (README, SECURITY, CONTRIBUTING, CODE_OF_CONDUCT) at repo root; other docs in `docs/`;
+  diagram sources and SVG in `docs/assets/`.
+- **Maintain**: system overview; cross-repo context; one diagram per major data flow (don't collapse); sequence diagrams for
+  complex multi-party interactions (auth, API chains, CI); component/deployment diagrams for non-trivial topology.
+- **Style**: inline Mermaid per doc section; standalone SVG for top-level overviews linked from README.
+  One diagram per concern — a diagram showing everything shows nothing.
 
 ## Model Routing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,8 +156,8 @@ See soul.md section 4 — no emoji; conventional-commit prefixes for subjects/ti
 | Use case | Format | Placement |
 | --- | --- | --- |
 | Inline with Markdown | Fenced `mermaid` code block | Inside the `.md` file |
-| Standalone high-level diagram | SVG file | `docs/assets/` |
-| Diagram source | `.mmd` file | `docs/assets/` (alongside SVG) |
+| Standalone diagram source | `.mmd` file | `docs/assets/` |
+| Standalone rendered diagram | SVG (generated from `.mmd`) | `docs/assets/` |
 
 GitHub renders fenced `mermaid` blocks natively — no image upload or external service needed.
 Generate SVG from source: `nix run nixpkgs#mermaid-cli -- -i diagram.mmd -o diagram.svg`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repo is the universal config layer for the JacobPEvans AI ecosystem, sittin
 graph TD
     AAI["**ai-assistant-instructions**\nUniversal AI config layer"]
 
-    NixAI["**nix-ai**\nAI tool ecosystem\nClaude Code · MCP servers · Whisper"]
+    NixAI["**nix-ai**\nAI tool ecosystem\nClaude Code · Gemini · MCP servers · Whisper"]
     NixHome["**nix-home** / **nix-darwin**\nUser + system environments"]
 
     Plugins["**claude-code-plugins**\nCommands · skills · hooks"]
@@ -41,7 +41,7 @@ graph TD
     NixAI --> NixHome
 ```
 
-See [`docs/assets/`](docs/assets/) for full architecture and session-lifecycle diagrams.
+See [`docs/diagrams.md`](docs/diagrams.md) for full architecture and session-lifecycle diagrams.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@ Drop these into your projects and get consistent, high-quality AI assistance acr
 
 Think of it as a style guide, but for your AI pair programmer.
 
+### Ecosystem Context
+
+This repo is the universal config layer for the JacobPEvans AI ecosystem, sitting above the Nix infrastructure repos and feeding rules into every per-repo AI session:
+
+```mermaid
+graph TD
+    AAI["**ai-assistant-instructions**\nUniversal AI config layer"]
+
+    NixAI["**nix-ai**\nAI tool ecosystem\nClaude Code · MCP servers · Whisper"]
+    NixHome["**nix-home** / **nix-darwin**\nUser + system environments"]
+
+    Plugins["**claude-code-plugins**\nCommands · skills · hooks"]
+    PerRepo["**Per-repo CLAUDE.md**\n@AGENTS.md import"]
+
+    AAI -->|"dispatch webhook"| NixAI
+    AAI -->|"@AGENTS.md"| PerRepo
+    Plugins -->|"marketplace install"| PerRepo
+    NixAI --> NixHome
+```
+
+See [`docs/assets/`](docs/assets/) for full architecture and session-lifecycle diagrams.
+
 ## Prerequisites
 
 - **Git 2.30+** (for worktree support)

--- a/docs/assets/architecture.mmd
+++ b/docs/assets/architecture.mmd
@@ -1,0 +1,31 @@
+---
+title: ai-assistant-instructions Repository Architecture
+---
+graph TD
+    AGENTS["**AGENTS.md**\nCanonical config source"]
+    CLAUDE["CLAUDE.md / GEMINI.md\n(symlinks → AGENTS.md)"]
+    COPILOT[".copilot/instructions.md\n(symlink → AGENTS.md)"]
+
+    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · no-scripts\n· secrets-policy · bifrost-routing\n· nix-tool-policy · ci-cd-policy …"]
+    Workflows["**agentsmd/workflows/**\n5-step development process\n1 Research → 2 Plan → 3 Define\n4 Implement → 5 Finalize"]
+    Permissions["**agentsmd/permissions/**\nTool access control\nallow / ask / deny (JSON)"]
+
+    Docs["**docs/**\nUser-facing guides\n· codex-quick-start\n· troubleshooting\n· github-actions"]
+    Assets["**docs/assets/**\nDiagram sources (.mmd)\nand rendered SVG files"]
+
+    CI[".github/workflows/\nCI validation gates\n· markdownlint · token-limits\n· link-check · CodeQL · release"]
+
+    AGENTS --> CLAUDE
+    AGENTS --> COPILOT
+    AGENTS -->|"auto-loaded"| Rules
+    AGENTS -->|"governs"| Workflows
+    AGENTS -->|"enforces"| Permissions
+    Rules --> CI
+    Permissions --> CI
+    Docs --> Assets
+
+    style AGENTS fill:#d4e6ff,stroke:#4a90d9,color:#000
+    style Rules fill:#d4ffd4,stroke:#4a9d4a,color:#000
+    style Workflows fill:#d4ffd4,stroke:#4a9d4a,color:#000
+    style Permissions fill:#d4ffd4,stroke:#4a9d4a,color:#000
+    style CI fill:#ffd4d4,stroke:#d94a4a,color:#000

--- a/docs/assets/architecture.mmd
+++ b/docs/assets/architecture.mmd
@@ -1,9 +1,8 @@
----
-title: ai-assistant-instructions Repository Architecture
----
+%% Internal architecture of the ai-assistant-instructions repository
 graph TD
     AGENTS["**AGENTS.md**\nCanonical config source"]
-    CLAUDE["CLAUDE.md / GEMINI.md\n(symlinks → AGENTS.md)"]
+    CLAUDE["CLAUDE.md\n(@AGENTS.md import)"]
+    GEMINI["GEMINI.md\n(synced document)"]
     COPILOT[".copilot/instructions.md\n(symlink → AGENTS.md)"]
 
     Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · no-scripts\n· secrets-policy · bifrost-routing\n· nix-tool-policy · ci-cd-policy …"]
@@ -11,11 +10,12 @@ graph TD
     Permissions["**agentsmd/permissions/**\nTool access control\nallow / ask / deny (JSON)"]
 
     Docs["**docs/**\nUser-facing guides\n· codex-quick-start\n· troubleshooting\n· github-actions"]
-    Assets["**docs/assets/**\nDiagram sources (.mmd)\nand rendered SVG files"]
+    Assets["**docs/assets/**\nDiagram sources (.mmd)\nSVG rendered on demand"]
 
     CI[".github/workflows/\nCI validation gates\n· markdownlint · token-limits\n· link-check · CodeQL · release"]
 
     AGENTS --> CLAUDE
+    AGENTS --> GEMINI
     AGENTS --> COPILOT
     AGENTS -->|"auto-loaded"| Rules
     AGENTS -->|"governs"| Workflows

--- a/docs/assets/ecosystem.mmd
+++ b/docs/assets/ecosystem.mmd
@@ -1,0 +1,27 @@
+---
+title: JacobPEvans AI Ecosystem
+---
+graph TD
+    AAI["**ai-assistant-instructions**\nUniversal AI config layer\n(AGENTS.md · rules · workflows · permissions)"]
+
+    NixAI["**nix-ai**\nAI tool ecosystem\n(Claude Code · Gemini · MCP servers · Whisper)"]
+    NixHome["**nix-home**\nUser dev environment\n(dev tools · shell · git · linters)"]
+    NixDarwin["**nix-darwin**\nmacOS system config\n(system packages · LaunchDaemons · security)"]
+    NixDevenv["**nix-devenv**\nProject shells\n(per-language toolchains · importable modules)"]
+
+    Plugins["**claude-code-plugins**\nCommands · skills · agents · hooks"]
+
+    PerRepo["**Per-repo CLAUDE.md**\n@AGENTS.md import"]
+
+    AAI -->|"dispatch webhook\n(trigger-nix-update)"| NixAI
+    AAI -->|"@AGENTS.md\ncanonicalsource"| PerRepo
+    Plugins -->|"marketplace install\nskills · slash commands"| PerRepo
+
+    NixAI -->|"home.packages"| NixHome
+    NixDarwin -->|"system layer"| NixHome
+    NixHome -->|"imports"| NixDevenv
+
+    style AAI fill:#d4e6ff,stroke:#4a90d9,color:#000
+    style NixAI fill:#d4ffd4,stroke:#4a9d4a,color:#000
+    style Plugins fill:#fff3d4,stroke:#d4a017,color:#000
+    style PerRepo fill:#f0d4ff,stroke:#9b4ad9,color:#000

--- a/docs/assets/ecosystem.mmd
+++ b/docs/assets/ecosystem.mmd
@@ -1,6 +1,4 @@
----
-title: JacobPEvans AI Ecosystem
----
+%% Ecosystem context: how ai-assistant-instructions fits into the JacobPEvans nix-ai system
 graph TD
     AAI["**ai-assistant-instructions**\nUniversal AI config layer\n(AGENTS.md · rules · workflows · permissions)"]
 
@@ -14,7 +12,7 @@ graph TD
     PerRepo["**Per-repo CLAUDE.md**\n@AGENTS.md import"]
 
     AAI -->|"dispatch webhook\n(trigger-nix-update)"| NixAI
-    AAI -->|"@AGENTS.md\ncanonicalsource"| PerRepo
+    AAI -->|"@AGENTS.md\ncanonical source"| PerRepo
     Plugins -->|"marketplace install\nskills · slash commands"| PerRepo
 
     NixAI -->|"home.packages"| NixHome

--- a/docs/assets/session-lifecycle.mmd
+++ b/docs/assets/session-lifecycle.mmd
@@ -1,0 +1,28 @@
+---
+title: AI Agent Session Lifecycle
+---
+sequenceDiagram
+    actor Dev as Developer
+    participant CC as Claude Code
+    participant Repo as Per-repo CLAUDE.md
+    participant AAI as ai-assistant-instructions
+    participant Plugins as claude-code-plugins
+
+    Dev->>CC: Start session
+    CC->>Repo: Read CLAUDE.md
+    Repo->>AAI: @AGENTS.md import resolves
+    AAI-->>CC: Canonical rules + routing loaded
+    CC->>AAI: Auto-load agentsmd/rules/
+    AAI-->>CC: tool-use, soul, no-scripts, secrets-policy, …
+    CC->>Plugins: Load installed skills & hooks
+    Plugins-->>CC: PreToolUse / PostToolUse hooks active
+
+    Dev->>CC: /refresh-repo (or other slash command)
+    CC->>Plugins: Invoke skill
+    Plugins-->>Dev: Result
+
+    Dev->>CC: Implement feature
+    CC->>CC: Apply rules (no-scripts, surgical changes, …)
+    CC-->>Dev: Code + commit
+
+    Note over CC,AAI: Rules re-read from disk each session — no stale cache

--- a/docs/assets/session-lifecycle.mmd
+++ b/docs/assets/session-lifecycle.mmd
@@ -1,6 +1,4 @@
----
-title: AI Agent Session Lifecycle
----
+%% AI agent session lifecycle: from session start through implementation
 sequenceDiagram
     actor Dev as Developer
     participant CC as Claude Code

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -1,0 +1,119 @@
+# Architecture Diagrams
+
+## Ecosystem Context
+
+Where `ai-assistant-instructions` fits within the broader JacobPEvans nix-ai system.
+
+```mermaid
+graph TD
+    AAI["**ai-assistant-instructions**\nUniversal AI config layer\n(AGENTS.md · rules · workflows · permissions)"]
+
+    NixAI["**nix-ai**\nAI tool ecosystem\n(Claude Code · Gemini · MCP servers · Whisper)"]
+    NixHome["**nix-home**\nUser dev environment\n(dev tools · shell · git · linters)"]
+    NixDarwin["**nix-darwin**\nmacOS system config\n(system packages · LaunchDaemons · security)"]
+    NixDevenv["**nix-devenv**\nProject shells\n(per-language toolchains · importable modules)"]
+
+    Plugins["**claude-code-plugins**\nCommands · skills · agents · hooks"]
+
+    PerRepo["**Per-repo CLAUDE.md**\n@AGENTS.md import"]
+
+    AAI -->|"dispatch webhook\n(trigger-nix-update)"| NixAI
+    AAI -->|"@AGENTS.md\ncanonical source"| PerRepo
+    Plugins -->|"marketplace install\nskills · slash commands"| PerRepo
+
+    NixAI -->|"home.packages"| NixHome
+    NixDarwin -->|"system layer"| NixHome
+    NixHome -->|"imports"| NixDevenv
+
+    style AAI fill:#d4e6ff,stroke:#4a90d9,color:#000
+    style NixAI fill:#d4ffd4,stroke:#4a9d4a,color:#000
+    style Plugins fill:#fff3d4,stroke:#d4a017,color:#000
+    style PerRepo fill:#f0d4ff,stroke:#9b4ad9,color:#000
+```
+
+Source: [`docs/assets/ecosystem.mmd`](assets/ecosystem.mmd)
+
+---
+
+## Repository Architecture
+
+Internal structure of this repository and how the pieces relate.
+
+```mermaid
+graph TD
+    AGENTS["**AGENTS.md**\nCanonical config source"]
+    CLAUDE["CLAUDE.md\n(@AGENTS.md import)"]
+    GEMINI["GEMINI.md\n(synced document)"]
+    COPILOT[".copilot/instructions.md\n(symlink → AGENTS.md)"]
+
+    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · no-scripts\n· secrets-policy · bifrost-routing\n· nix-tool-policy · ci-cd-policy …"]
+    Workflows["**agentsmd/workflows/**\n5-step development process\n1 Research → 2 Plan → 3 Define\n4 Implement → 5 Finalize"]
+    Permissions["**agentsmd/permissions/**\nTool access control\nallow / ask / deny (JSON)"]
+
+    Docs["**docs/**\nUser-facing guides\n· codex-quick-start\n· troubleshooting\n· github-actions"]
+    Assets["**docs/assets/**\nDiagram sources (.mmd)\nSVG rendered on demand"]
+
+    CI[".github/workflows/\nCI validation gates\n· markdownlint · token-limits\n· link-check · CodeQL · release"]
+
+    AGENTS --> CLAUDE
+    AGENTS --> GEMINI
+    AGENTS --> COPILOT
+    AGENTS -->|"auto-loaded"| Rules
+    AGENTS -->|"governs"| Workflows
+    AGENTS -->|"enforces"| Permissions
+    Rules --> CI
+    Permissions --> CI
+    Docs --> Assets
+
+    style AGENTS fill:#d4e6ff,stroke:#4a90d9,color:#000
+    style Rules fill:#d4ffd4,stroke:#4a9d4a,color:#000
+    style Workflows fill:#d4ffd4,stroke:#4a9d4a,color:#000
+    style Permissions fill:#d4ffd4,stroke:#4a9d4a,color:#000
+    style CI fill:#ffd4d4,stroke:#d94a4a,color:#000
+```
+
+Source: [`docs/assets/architecture.mmd`](assets/architecture.mmd)
+
+---
+
+## AI Agent Session Lifecycle
+
+Sequence of events from session start through implementation for a Claude Code session.
+
+```mermaid
+sequenceDiagram
+    actor Dev as Developer
+    participant CC as Claude Code
+    participant Repo as Per-repo CLAUDE.md
+    participant AAI as ai-assistant-instructions
+    participant Plugins as claude-code-plugins
+
+    Dev->>CC: Start session
+    CC->>Repo: Read CLAUDE.md
+    Repo->>AAI: @AGENTS.md import resolves
+    AAI-->>CC: Canonical rules + routing loaded
+    CC->>AAI: Auto-load agentsmd/rules/
+    AAI-->>CC: tool-use, soul, no-scripts, secrets-policy, …
+    CC->>Plugins: Load installed skills & hooks
+    Plugins-->>CC: PreToolUse / PostToolUse hooks active
+
+    Dev->>CC: /refresh-repo (or other slash command)
+    CC->>Plugins: Invoke skill
+    Plugins-->>Dev: Result
+
+    Dev->>CC: Implement feature
+    CC->>CC: Apply rules (no-scripts, surgical changes, …)
+    CC-->>Dev: Code + commit
+
+    Note over CC,AAI: Rules re-read from disk each session — no stale cache
+```
+
+Source: [`docs/assets/session-lifecycle.mmd`](assets/session-lifecycle.mmd)
+
+---
+
+To render `.mmd` sources to SVG locally:
+
+```bash
+nix run nixpkgs#mermaid-cli -- -i docs/assets/ecosystem.mmd -o docs/assets/ecosystem.svg
+```


### PR DESCRIPTION
## Summary

- Establishes diagramming practices within AGENTS.md to standardize Mermaid diagram creation, placement, and maintenance across the ai-assistant-instructions ecosystem
- Adds three standalone diagram sources (ecosystem.mmd, architecture.mmd, session-lifecycle.mmd) under docs/assets/ with on-demand SVG rendering
- Refactored diagramming section from 36 lines down to 8 focused bullets, preserving all instructions while reducing token footprint (critical given AGENTS.md is loaded every session)

## Changes

- feat(agents): Diagramming section in AGENTS.md with 4 bullets covering format, placement, granularity, and style
- feat(docs): Three .mmd diagram sources under docs/assets/ (ecosystem, architecture, session-lifecycle)
- feat(docs): New docs/diagrams.md page documenting rendering process and source files
- feat(readme): Inline ecosystem Mermaid block added to README.md
- fix(docs): Address Copilot review comments on diagram labels and metadata

## Test Plan

- markdownlint validates AGENTS.md and docs/ Markdown syntax
- link-check verifies all intra-repo and external links in docs/diagrams.md
- CodeQL runs standard security checks on all repo content
- Manual verification: SVG rendering via `nix run nixpkgs#mermaid-cli -- docs/assets/*.mmd`