### PR TITLE
fix(docs): shorten Rules mermaid label to fix MD013 line-length

### DIFF
--- a/docs/assets/architecture.mmd
+++ b/docs/assets/architecture.mmd
@@ -5,7 +5,7 @@ graph TD
     GEMINI["GEMINI.md\n(synced document)"]
     COPILOT[".copilot/instructions.md\n(symlink → AGENTS.md)"]
 
-    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · no-scripts\n· secrets-policy · bifrost-routing\n· nix-tool-policy · ci-cd-policy …"]
+    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · no-scripts\n· secrets-policy · bifrost-routing\n· nix-tool-policy …"]
     Workflows["**agentsmd/workflows/**\n5-step development process\n1 Research → 2 Plan → 3 Define\n4 Implement → 5 Finalize"]
     Permissions["**agentsmd/permissions/**\nTool access control\nallow / ask / deny (JSON)"]
 

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -46,7 +46,7 @@ graph TD
     GEMINI["GEMINI.md\n(synced document)"]
     COPILOT[".copilot/instructions.md\n(symlink → AGENTS.md)"]
 
-    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · no-scripts\n· secrets-policy · bifrost-routing\n· nix-tool-policy · ci-cd-policy …"]
+    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · no-scripts\n· secrets-policy · bifrost-routing\n· nix-tool-policy …"]
     Workflows["**agentsmd/workflows/**\n5-step development process\n1 Research → 2 Plan → 3 Define\n4 Implement → 5 Finalize"]
     Permissions["**agentsmd/permissions/**\nTool access control\nallow / ask / deny (JSON)"]
 


### PR DESCRIPTION
## Summary
- Trim trailing rule names from the `Rules` mermaid node in `docs/diagrams.md:49`
- Brings the line under markdownlint's MD013 160-char limit

## Why
The post-merge Markdown Lint workflow has been failing on `main` since release 1.12.1:
```
docs/diagrams.md:49:161 MD013/line-length Line length [Expected: 160; Actual: 163]
```

The Rules node listed enough example rules to push the line to 163 chars. Trimming `· ci-cd-policy …` keeps the same conceptual content (a few representative rule names) while fitting the limit.

## Test plan
- [ ] CI Markdown Lint passes
- [ ] Mermaid diagram still renders correctly on GitHub

Assisted-by: Claude <noreply@anthropic.com>