### PR TITLE
docs(rules): require keychain secret reuse via shell variable

### DIFF
--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -74,13 +74,13 @@ needs it. Never inline `$(security find-generic-password ...)` in each command.
 
 ```bash
 # WRONG — prompts on every command
-curl -H "Authorization: Bearer $(security find-generic-password -s GITHUB_TOKEN -w)" https://api.github.com/user
-curl -H "Authorization: Bearer $(security find-generic-password -s GITHUB_TOKEN -w)" https://api.github.com/repos/JacobPEvans/ai-assistant-instructions
+TF_VAR_anthropic_key=$(security find-generic-password -s ANTHROPIC_API_KEY -w) terragrunt plan
+TF_VAR_anthropic_key=$(security find-generic-password -s ANTHROPIC_API_KEY -w) terragrunt apply
 
 # CORRECT — one prompt, then inject the variable
-GITHUB_TOKEN=$(security find-generic-password -s GITHUB_TOKEN -w)
-curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
-curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/JacobPEvans/ai-assistant-instructions
+ANTHROPIC_API_KEY=$(security find-generic-password -s ANTHROPIC_API_KEY -w)
+TF_VAR_anthropic_key=$ANTHROPIC_API_KEY terragrunt plan
+TF_VAR_anthropic_key=$ANTHROPIC_API_KEY terragrunt apply
 ```
 
 Applies to any keychain-backed secret and any `security find-*-password` invocation.

--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -69,9 +69,10 @@ provider "proxmox" {
 ### macOS Keychain Reuse
 
 **Each keychain read triggers a password approval prompt.** When a secret is
-used across multiple commands in the same session, fetch it once into a shell
-variable and reuse the variable. Never inline `$(security find-generic-password ...)`
-inside each command — that prompts the user once per command.
+used across multiple commands in the same session, fetch it once into a transient
+shell variable (not exported, not persisted) and reuse the variable. Never inline
+`$(security find-generic-password ...)` inside each command — that prompts the
+user once per command.
 
 ```bash
 # WRONG — prompts on every command

--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -77,13 +77,20 @@ user once per command.
 ```bash
 # WRONG — prompts on every command
 curl -H "Authorization: Bearer $(security find-generic-password -s GITHUB_TOKEN -w)" https://api.github.com/user
-gh auth login --with-token <<<"$(security find-generic-password -s GITHUB_TOKEN -w)"
+curl -H "Authorization: Bearer $(security find-generic-password -s GITHUB_TOKEN -w)" https://api.github.com/repos/JacobPEvans/ai-assistant-instructions
 
-# CORRECT — one prompt, then reuse the variable
+# CORRECT — one prompt, then inject the variable into each command
 GITHUB_TOKEN=$(security find-generic-password -s GITHUB_TOKEN -w)
 curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
-gh auth login --with-token <<<"$GITHUB_TOKEN"
+GH_TOKEN="$GITHUB_TOKEN" gh api repos/JacobPEvans/ai-assistant-instructions
 ```
+
+**Inject the variable, never persist it.** Use either an inline expansion
+(`-H "...$VAR"`) or a per-command env-var prefix (`GH_TOKEN="$VAR" gh ...`).
+Both scope the secret to one process. **Never write the secret to disk or to
+shared global state.** That includes `gh auth login --with-token` (writes to
+`~/.config/gh/hosts.yml` — affects every shell and every other Claude
+session), `git config --global`, shell profiles, or any persistent config file.
 
 The same rule applies to any other keychain-backed secret (`OPENAI_API_KEY`,
 `ANTHROPIC_API_KEY`, etc.) and to any `security find-*-password` invocation.

--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -68,29 +68,19 @@ provider "proxmox" {
 
 ### macOS Keychain Reuse
 
-**Each keychain read triggers a password approval prompt.** When a secret is
-used across multiple commands in the same session, fetch it once into a transient
-shell variable (not exported, not persisted) and reuse the variable. Never inline
-`$(security find-generic-password ...)` inside each command — that prompts the
-user once per command.
+**Each keychain read triggers a password approval prompt.** Fetch the secret
+once into a shell variable, then inject the variable into every command that
+needs it. Never inline `$(security find-generic-password ...)` in each command.
 
 ```bash
 # WRONG — prompts on every command
 curl -H "Authorization: Bearer $(security find-generic-password -s GITHUB_TOKEN -w)" https://api.github.com/user
 curl -H "Authorization: Bearer $(security find-generic-password -s GITHUB_TOKEN -w)" https://api.github.com/repos/JacobPEvans/ai-assistant-instructions
 
-# CORRECT — one prompt, then inject the variable into each command
+# CORRECT — one prompt, then inject the variable
 GITHUB_TOKEN=$(security find-generic-password -s GITHUB_TOKEN -w)
 curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
-GH_TOKEN="$GITHUB_TOKEN" gh api repos/JacobPEvans/ai-assistant-instructions
+curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/JacobPEvans/ai-assistant-instructions
 ```
 
-**Inject the variable, never persist it.** Use either an inline expansion
-(`-H "...$VAR"`) or a per-command env-var prefix (`GH_TOKEN="$VAR" gh ...`).
-Both scope the secret to one process. **Never write the secret to disk or to
-shared global state.** That includes `gh auth login --with-token` (writes to
-`~/.config/gh/hosts.yml` — affects every shell and every other Claude
-session), `git config --global`, shell profiles, or any persistent config file.
-
-The same rule applies to any other keychain-backed secret (`OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, etc.) and to any `security find-*-password` invocation.
+Applies to any keychain-backed secret and any `security find-*-password` invocation.

--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -65,3 +65,24 @@ provider "proxmox" {
 - **Environment Variables**: CI/CD secrets or local .env (never committed)
 - **AWS Secrets Manager / Parameter Store**: For AWS deployments
 - **SSH Agent**: Agent forwarding only, never commit keys
+
+### macOS Keychain Reuse
+
+**Each keychain read triggers a password approval prompt.** When a secret is
+used across multiple commands in the same session, fetch it once into a shell
+variable and reuse the variable. Never inline `$(security find-generic-password ...)`
+inside each command — that prompts the user once per command.
+
+```bash
+# WRONG — prompts on every command
+curl -H "Authorization: Bearer $(security find-generic-password -s GITHUB_TOKEN -w)" https://api.github.com/user
+gh auth login --with-token <<<"$(security find-generic-password -s GITHUB_TOKEN -w)"
+
+# CORRECT — one prompt, then reuse the variable
+GITHUB_TOKEN=$(security find-generic-password -s GITHUB_TOKEN -w)
+curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
+gh auth login --with-token <<<"$GITHUB_TOKEN"
+```
+
+The same rule applies to any other keychain-backed secret (`OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, etc.) and to any `security find-*-password` invocation.


### PR DESCRIPTION
## Summary
- Add a macOS keychain reuse rule to `agentsmd/rules/config-secrets.md`.
- Each `security find-generic-password` call triggers a GUI password approval prompt; inlining it in multiple commands prompts the user once per command.
- New rule mandates fetching the secret once into a transient shell variable (not exported, not persisted) and reusing it, with wrong/right `bash` examples. The "transient" wording disambiguates from line 62's prohibition on persistent env vars.

## Test plan
- [x] `pre-commit run --files agentsmd/rules/config-secrets.md` passes (markdownlint, link check, trailing whitespace)
- [x] CodeQL clean, CI green, gemini-code-assist feedback applied and resolved
- [ ] In a new session, verify the assistant assigns once and reuses `$VAR` instead of repeating `$(security find-generic-password ...)`