### PR TITLE
docs(rules): name canonical public-docs target and mandate portable defaults

### DIFF
--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -15,6 +15,11 @@ paths:
 
 # Config File Secrets
 
+See [`secrets-policy.md`](secrets-policy.md) for the broader "treat every
+repo as anyone's" posture and the canonical cross-repo public docs target
+([docs.jacobpevans.com](https://docs.jacobpevans.com)). This file is the
+config-file-specific application of those principles.
+
 ## Scrubbed Values
 
 | Type | Scrubbed Value | Examples |

--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -15,8 +15,8 @@ paths:
 
 # Config File Secrets
 
-See [`secrets-policy.md`](secrets-policy.md) for the broader "treat every
-repo as anyone's" posture and the canonical cross-repo public docs target
+See `secrets-policy.md` for the broader "treat every repo as anyone's"
+posture and the canonical cross-repo public docs target
 ([docs.jacobpevans.com](https://docs.jacobpevans.com)). This file is the
 config-file-specific application of those principles.
 

--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -15,10 +15,9 @@ paths:
 
 # Config File Secrets
 
-See `secrets-policy.md` for the broader "treat every repo as anyone's"
-posture and the canonical cross-repo public docs target
-([docs.jacobpevans.com](https://docs.jacobpevans.com)). This file is the
-config-file-specific application of those principles.
+See `secrets-policy.md` for the broader posture and the canonical
+cross-repo PUBLIC docs target
+([docs.jacobpevans.com](https://docs.jacobpevans.com)).
 
 ## Scrubbed Values
 

--- a/agentsmd/rules/secrets-policy.md
+++ b/agentsmd/rules/secrets-policy.md
@@ -1,69 +1,23 @@
 ---
 name: secrets-policy
-description: Never commit secrets, person-specific defaults, or private-repo identifiers. Cross-repo PUBLIC docs go to docs.jacobpevans.com. Placeholders EVERYWHERE — every repo as anyone's.
+description: No secrets, person-specific defaults, or private-repo IDs in commits. Cross-repo PUBLIC docs go to docs.jacobpevans.com. Use placeholders for anything tied to one user.
 ---
 
 # Secrets Policy
 
-**CRITICAL**: Never commit sensitive data to git.
-All git-committed files must use scrubbed values and variable references.
+Never commit: tokens, credentials, SSH keys, real IPs/hostnames/domains,
+AWS account IDs, user-specific paths, or person-specific defaults. Use
+placeholders or variables for anything tied to one user — every committed
+value should work for any person who clones the repo right now.
 
-## What NOT to Commit
-
-- API tokens, credentials, passwords
-- Real IP addresses (internal or external)
-- Real domain names or hostnames
-- SSH private keys or certificates
-- Database credentials
-- AWS account IDs, ARNs, or API keys
-- Encryption keys or secrets
-- User-specific absolute paths
-
-## Public vs Private Repository Separation
-
-Never reference private repos (names, features, tools) in public repo content.
-If a repo is private, treat it as if it doesn't exist when writing public-facing
-docs, sites, or READMEs.
-This includes repo names, project descriptions, architecture diagrams, and any
-identifying details.
-
-When updating public-facing content (GitHub Pages sites, public READMEs,
-portfolios), audit for any mentions of private repositories before committing.
-Use `gh repo view OWNER/REPO` to check visibility when in doubt.
-
-**Cross-repo PUBLIC documentation lives at
-[`docs.jacobpevans.com`](https://docs.jacobpevans.com)**
+Cross-repo PUBLIC documentation lives at
+[`docs.jacobpevans.com`](https://docs.jacobpevans.com)
 (source: [`github.com/JacobPEvans/docs`](https://github.com/JacobPEvans/docs)).
-Per-repo install / usage / API docs stay in the repo's own `README.md` and
-`docs/`. Portfolio-level, architectural, or cross-repo content goes on the
-docs site. Private repo content never reaches the docs site — if
-`gh repo view OWNER/REPO --json visibility` returns `PRIVATE`, treat the repo
-as if it does not exist when writing for the docs site.
+Per-repo docs stay in the repo's `README.md` and `docs/`. Private repos
+never appear there — verify with `gh repo view OWNER/REPO --json visibility`
+when in doubt.
 
-## Portable Defaults — Treat Every Repo as Anyone's
-
-Every committed value should work for any person who clones the repo right
-now. If a value names a person, a household network, a personal path, or a
-one-off number, replace it with a placeholder, variable, or scrubbed
-equivalent.
-
-**Placeholders and variables EVERYWHERE possible. No hard-coded values.
-No magic numbers. No person-specific defaults.**
-
-| Person-specific shape (wrong) | Portable (right) |
-| --- | --- |
-| `username: <real-handle>` | `username: ${USER}` or `username: admin` |
-| `path: /Users/<name>/git/foo` | `path: ${REPO_ROOT}` or relative path |
-| `host: nas.<name>.local` | `host: ${NAS_HOST}` or `host: nas.example.local` |
-| `email: <name>@<provider>.com` | `email: ${MAINTAINER_EMAIL}` |
-| `api_token: "pat_<redacted>"` | `api_token: var.api_token` (Keychain / SOPS / env) |
-| `timeout = 47` (no rationale) | `timeout = DEFAULT_TIMEOUT_SECONDS` (named constant with documented default) |
-
-**Never write the real value even as a "wrong example."** The example
-itself becomes committed text — use shape stand-ins (`<name>`,
-`<real-handle>`, `<redacted>`) so the table teaches the pattern without
-leaking the value.
-
-Magic numbers: any literal that needs a comment to explain it should be a
-named constant or variable. See `config-secrets.md` for the canonical
-scrubbed-value table and runtime injection methods.
+Never write a real value even in a "wrong" example — the example becomes
+committed text. Use shape stand-ins: `${USER}`, `${REPO_ROOT}`,
+`${MAINTAINER_EMAIL}`, `${NAS_HOST}`, `<redacted>`. See `config-secrets.md`
+for the canonical scrubbed-value table and runtime injection methods.

--- a/agentsmd/rules/secrets-policy.md
+++ b/agentsmd/rules/secrets-policy.md
@@ -1,23 +1,6 @@
 ---
 name: secrets-policy
-description: Never commit secrets, credentials, or sensitive data — use variable references; keep private repo identifiers out of public docs and READMEs
-paths:
-  - "**/.env*"
-  - "**/*.json"
-  - "**/*.yaml"
-  - "**/*.yml"
-  - "**/*.toml"
-  - "**/*.tf"
-  - "**/*.tfvars"
-  - "**/*.nix"
-  - "**/Makefile"
-  - "**/.github/**"
-  - "**/docker-compose*"
-  - "**/Dockerfile*"
-  - "**/*.md"
-  - "**/*.mdx"
-  - "README*"
-  - "docs/**"
+description: Never commit secrets, person-specific defaults, or private-repo identifiers. Cross-repo PUBLIC documentation goes to docs.jacobpevans.com (source github.com/JacobPEvans/docs). Placeholders and variables EVERYWHERE — treat every repo as if any person will clone and use it right now.
 ---
 
 # Secrets Policy
@@ -47,3 +30,40 @@ identifying details.
 When updating public-facing content (GitHub Pages sites, public READMEs,
 portfolios), audit for any mentions of private repositories before committing.
 Use `gh repo view OWNER/REPO` to check visibility when in doubt.
+
+**Cross-repo PUBLIC documentation lives at
+[`docs.jacobpevans.com`](https://docs.jacobpevans.com)**
+(source: [`github.com/JacobPEvans/docs`](https://github.com/JacobPEvans/docs)).
+Per-repo install / usage / API docs stay in the repo's own `README.md` and
+`docs/`. Portfolio-level, architectural, or cross-repo content goes on the
+docs site. Private repo content never reaches the docs site — if
+`gh repo view OWNER/REPO --json visibility` returns `PRIVATE`, treat the repo
+as if it does not exist when writing for the docs site.
+
+## Portable Defaults — Treat Every Repo as Anyone's
+
+Every committed value should work for any person who clones the repo right
+now. If a value names a person, a household network, a personal path, or a
+one-off number, replace it with a placeholder, variable, or scrubbed
+equivalent.
+
+**Placeholders and variables EVERYWHERE possible. No hard-coded values.
+No magic numbers. No person-specific defaults.**
+
+| Person-specific shape (wrong) | Portable (right) |
+| --- | --- |
+| `username: <real-handle>` | `username: ${USER}` or `username: admin` |
+| `path: /Users/<name>/git/foo` | `path: ${REPO_ROOT}` or relative path |
+| `host: nas.<name>.local` | `host: ${NAS_HOST}` or `host: nas.example.local` |
+| `email: <name>@<provider>.com` | `email: ${MAINTAINER_EMAIL}` |
+| `api_token: "pat_<redacted>"` | `api_token: var.api_token` (Keychain / SOPS / env) |
+| `timeout = 47` (no rationale) | `timeout = DEFAULT_TIMEOUT_SECONDS` (named constant with documented default) |
+
+**Never write the real value even as a "wrong example."** The example
+itself becomes committed text — use shape stand-ins (`<name>`,
+`<real-handle>`, `<redacted>`) so the table teaches the pattern without
+leaking the value.
+
+Magic numbers: any literal that needs a comment to explain it should be a
+named constant or variable. See [`config-secrets.md`](config-secrets.md) for
+the canonical scrubbed-value table and runtime injection methods.

--- a/agentsmd/rules/secrets-policy.md
+++ b/agentsmd/rules/secrets-policy.md
@@ -1,6 +1,6 @@
 ---
 name: secrets-policy
-description: Never commit secrets, person-specific defaults, or private-repo identifiers. Cross-repo PUBLIC documentation goes to docs.jacobpevans.com (source github.com/JacobPEvans/docs). Placeholders and variables EVERYWHERE — treat every repo as if any person will clone and use it right now.
+description: Never commit secrets, person-specific defaults, or private-repo identifiers. Cross-repo PUBLIC docs go to docs.jacobpevans.com. Placeholders EVERYWHERE — every repo as anyone's.
 ---
 
 # Secrets Policy
@@ -65,5 +65,5 @@ itself becomes committed text — use shape stand-ins (`<name>`,
 leaking the value.
 
 Magic numbers: any literal that needs a comment to explain it should be a
-named constant or variable. See [`config-secrets.md`](config-secrets.md) for
-the canonical scrubbed-value table and runtime injection methods.
+named constant or variable. See `config-secrets.md` for the canonical
+scrubbed-value table and runtime injection methods.


### PR DESCRIPTION
## Summary

Adds two pieces of always-loaded guidance to `agentsmd/rules/secrets-policy.md`:

- **Cross-repo PUBLIC documentation target**: [`docs.jacobpevans.com`](https://docs.jacobpevans.com) (source: [`github.com/JacobPEvans/docs`](https://github.com/JacobPEvans/docs)). Per-repo docs stay in-repo; portfolio/architectural/cross-repo content goes to the docs site. Private repos never reach it.
- **Portable defaults**: use placeholders or variables for anything tied to one user — every committed value should work for any person who clones the repo right now. Includes inline shape stand-ins and an explicit prohibition on writing real values even as "wrong" examples (the example becomes committed text).

Drops `paths:` from `secrets-policy.md` so the rule loads in every session rather than only on certain file types. Because it's now always-loaded, the file was aggressively consolidated to 23 lines (down from 70): three short prose paragraphs replace 6 sections, an 8-bullet never-commit list, a 6-row example table, and several meta-warnings. Every load-bearing piece is preserved: the URL, the source repo, the visibility gate, the real-value warning, the shape stand-ins.

`config-secrets.md` gets a 3-line cross-reference to the broader posture and keeps its file-specific scrubbed-value table.

## Why one file, not two new

Reviewed existing rules first. `secrets-policy.md` already covered Public vs Private repository separation and the never-commit list; both new themes fit naturally there. Adding new files would have duplicated scope.

## Test plan

- [x] `pre-commit run --files agentsmd/rules/secrets-policy.md agentsmd/rules/config-secrets.md` — passes (markdownlint, links, whitespace)
- [x] Token-limit check — passes
- [x] All CI checks SUCCESS, CodeQL 0 alerts, 0 unresolved review threads
- [ ] Post-merge smoke test: in a fresh session in any repo, ask "where do cross-repo architecture docs go?" → answer should name `docs.jacobpevans.com` without prompting; ask about a person-specific default → answer should cite the portable-defaults guidance.

Earlier review feedback addressed in commits 80fff06 and 0e8530e (frontmatter description tightening, intra-agentsmd cross-refs converted to plain backticks, aggressive consolidation for always-load efficiency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)