### PR TITLE
docs(config-secrets): link to consolidated security docs

### DIFF
--- a/agentsmd/rules/config-secrets.md
+++ b/agentsmd/rules/config-secrets.md
@@ -15,9 +15,26 @@ paths:
 
 # Config File Secrets
 
-See `secrets-policy.md` for the broader posture and the canonical
-cross-repo PUBLIC docs target
-([docs.jacobpevans.com](https://docs.jacobpevans.com)).
+See `secrets-policy.md` for the broader posture. The canonical cross-repo
+PUBLIC narrative — golden laws, per-tool deep dives, cross-tool flow
+diagrams, local AI isolation guarantees — lives at:
+
+- [Security overview](https://docs.jacobpevans.com/security/overview)
+  — decision tree, which tool for which secret.
+- [Golden laws](https://docs.jacobpevans.com/security/golden-laws)
+  — the 15 non-negotiable rules. This file is one of their implementations.
+- Per-tool deep dives:
+  [Doppler](https://docs.jacobpevans.com/security/tools/doppler),
+  [macOS Keychain](https://docs.jacobpevans.com/security/tools/macos-keychain),
+  [AWS Vault](https://docs.jacobpevans.com/security/tools/aws-vault),
+  [SOPS](https://docs.jacobpevans.com/security/tools/sops),
+  [Bitwarden](https://docs.jacobpevans.com/security/tools/bitwarden),
+  [BWS](https://docs.jacobpevans.com/security/tools/bws),
+  [OpenBao](https://docs.jacobpevans.com/security/tools/openbao).
+
+This file is the operational rules layer — load-once, apply-everywhere
+agent guidance. Keep both in sync: the docs site explains the *why*,
+this file enforces the *how* in code.
 
 ## Scrubbed Values
 


### PR DESCRIPTION
## Summary

- Expand the top-of-file reference in `agentsmd/rules/config-secrets.md` from a single `docs.jacobpevans.com` mention to the full Security section link map.
- Specifically link to: overview (decision tree), golden laws (15 non-negotiable rules), and the seven per-tool deep dives (Doppler, macOS Keychain, AWS Vault, SOPS, Bitwarden, BWS, OpenBao).
- 23 insertions, 3 deletions in one file.

## Why

`config-secrets.md` is the operational rules layer — load-once, apply-everywhere agent guidance. The narrative for the *why* of each tool now lives at [docs.jacobpevans.com/security/*](https://docs.jacobpevans.com/security/overview); this file keeps the *how* for code. Linking explicitly to each tool makes the connection navigable.

This is one of ~10 follow-up PRs after [JacobPEvans/docs#14](https://github.com/JacobPEvans/docs/pull/14) lands.

## Test plan

- [ ] Click each link — verify they resolve once [JacobPEvans/docs#14](https://github.com/JacobPEvans/docs/pull/14) merges (links currently 404 until that PR ships).
- [ ] Verify the rest of `config-secrets.md` (Scrubbed Values, Portable Path References, Variable References, Runtime Secret Injection, macOS Keychain Reuse) is unchanged.

## Note on link timing

Until [JacobPEvans/docs#14](https://github.com/JacobPEvans/docs/pull/14) merges and Mintlify deploys (<5 min), the `docs.jacobpevans.com/security/*` links here will 404. The PR is technically mergeable in either order but it makes more sense to merge the docs PR first.

Assisted-by: Claude <noreply@anthropic.com>