### PR TITLE
feat(skill-overrides): disable noisy design-adjacent skills globally

### DIFF
--- a/agentsmd/settings/skill-overrides.json
+++ b/agentsmd/settings/skill-overrides.json
@@ -13,6 +13,9 @@
     "temporal-python-testing": "name-only",
     "django-pro": "off",
     "fastapi-pro": "off",
-    "graphql-architect": "off"
+    "graphql-architect": "off",
+    "slack-gif-creator": "off",
+    "algorithmic-art": "off",
+    "internal-comms": "off"
   }
 }

--- a/agentsmd/settings/skill-overrides.json
+++ b/agentsmd/settings/skill-overrides.json
@@ -14,8 +14,8 @@
     "django-pro": "off",
     "fastapi-pro": "off",
     "graphql-architect": "off",
-    "slack-gif-creator": "off",
     "algorithmic-art": "off",
-    "internal-comms": "off"
+    "internal-comms": "off",
+    "slack-gif-creator": "off"
   }
 }


### PR DESCRIPTION
## Summary

Add three `skillOverrides` entries set to `"off"` to keep them out of every session's context:

- `slack-gif-creator` — only useful when generating GIFs for Slack
- `algorithmic-art` — niche generative art use case
- `internal-comms` — company-internal communications writing

These ship in the `example-skills@anthropic-agent-skills` bundle being enabled in companion nix-ai PR (see [feat/anthropic-design-skills](https://github.com/JacobPEvans/nix-ai/pull/new/feat/anthropic-design-skills)). Without these overrides the bundle would auto-trigger on broad keywords (GIF, art, memo) outside design contexts.

The design skills proper (`frontend-design`, `theme-factory`, `brand-guidelines`, `web-artifacts-builder`, `canvas-design`, `webapp-testing`, `mcp-builder`, `skill-creator`) and `doc-coauthoring` are intentionally left at default ("on") so they auto-trigger contextually in docs work.

## Test plan

- [x] JSON validates
- [ ] After companion nix-ai PR + darwin-rebuild, fresh Claude Code session does not list these three skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)