### PR TITLE
docs: codify repo boundaries and docs update workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ in the same session — never leave it to a follow-up:
 - New user-facing rule under `agentsmd/rules/` → mention in
   `docs/ai-development/ai-assistant-instructions.mdx`.
 - Diagram edits → keep inline mermaid blocks and any `docs/assets/*.mmd` sources in lockstep
-  per `agentsmd/rules/diagramming.md`.
+  per `diagramming.md`.
 - One PR per repo. Cross-link via `Refs: JacobPEvans/<repo>#N` in the PR body.
 - Per-repo docs (the local `README.md` and `docs/` inside any source repo) stay in that repo.
   Private/user-only content never goes in `JacobPEvans/docs`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,35 @@ One-shot a local working solution. Surface upstream bugs as FYI; don't file PRs 
 outside the user's organizations. For multi-session work, use GitHub issues — never Claude Code's
 internal TODO as durable tracking.
 
+## Repo boundaries and docs
+
+The AI configuration layer spans three repos. Know which one owns the change before editing.
+
+| Owns | Repo |
+| --- | --- |
+| Auto-loaded rules, AGENTS.md, workflows, permission JSON | [`JacobPEvans/ai-assistant-instructions`](https://github.com/JacobPEvans/ai-assistant-instructions) |
+| Slash commands, skills, agents, hooks (marketplace-installed) | [`JacobPEvans/claude-code-plugins`](https://github.com/JacobPEvans/claude-code-plugins) |
+| Public-facing reference site at [`docs.jacobpevans.com`](https://docs.jacobpevans.com) | [`JacobPEvans/docs`](https://github.com/JacobPEvans/docs) |
+
+Canonical "what lives where" with diagram and lifecycle:
+[`docs.jacobpevans.com/ai-development/repo-boundaries`](https://docs.jacobpevans.com/ai-development/repo-boundaries).
+
+When a change in one repo affects the public picture, mirror the relevant slice into `JacobPEvans/docs`
+in the same session — never leave it to a follow-up:
+
+- Plugin added, removed, or scope shifted → update `docs/ai-development/claude-code-plugins.mdx`
+  and `docs/docs.json` nav.
+- New user-facing rule under `agentsmd/rules/` → mention in
+  `docs/ai-development/ai-assistant-instructions.mdx`.
+- Diagram edits → keep inline mermaid blocks and any `docs/assets/*.mmd` sources in lockstep
+  per `agentsmd/rules/diagramming.md`.
+- One PR per repo. Cross-link via `Refs: JacobPEvans/<repo>#N` in the PR body.
+- Per-repo docs (the local `README.md` and `docs/` inside any source repo) stay in that repo.
+  Private/user-only content never goes in `JacobPEvans/docs`.
+
+The docs site is descriptive (written for humans and AI readers); agent directives like this one
+stay in `AGENTS.md`.
+
 ## Delegation
 
 Protect the main context window. Delegate exploration and high-token research to subagents

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ graph LR
 
     style Rules fill:#d4e6ff,stroke:#4a90d9,color:#000
     style Plugins fill:#fff3d4,stroke:#d4a017,color:#000
-    style Docs fill:#f0d4ff,stroke:#9b4ad9,color:#000
+    style Docs fill:#e8d4ff,stroke:#8a4ad9,color:#000
 ```
 
 Full rule, decision table, and update workflow: [`docs.jacobpevans.com/ai-development/repo-boundaries`](https://docs.jacobpevans.com/ai-development/repo-boundaries).

--- a/README.md
+++ b/README.md
@@ -21,27 +21,32 @@ Drop these into your projects and get consistent, high-quality AI assistance acr
 
 Think of it as a style guide, but for your AI pair programmer.
 
-### Ecosystem Context
+### Repo boundaries
 
-This repo is the universal config layer for the JacobPEvans AI ecosystem, sitting above the Nix infrastructure repos and feeding rules into every per-repo AI session:
+The AI configuration layer is split across three repositories. This repo owns the rules.
+[`claude-code-plugins`](https://github.com/JacobPEvans/claude-code-plugins) owns commands, skills, agents, and hooks.
+[`docs`](https://github.com/JacobPEvans/docs) owns the public-facing reference site at
+[`docs.jacobpevans.com`](https://docs.jacobpevans.com).
 
 ```mermaid
-graph TD
-    AAI["**ai-assistant-instructions**\nUniversal AI config layer"]
+graph LR
+    Rules["**ai-assistant-instructions**<br/>rules · workflows · permissions"]
+    Plugins["**claude-code-plugins**<br/>commands · skills · agents · hooks"]
+    Docs["**docs**<br/>public-facing reference"]
+    Session(("Developer session"))
 
-    NixAI["**nix-ai**\nAI tool ecosystem\nClaude Code · Gemini · MCP servers · Whisper"]
-    NixHome["**nix-home** / **nix-darwin**\nUser + system environments"]
+    Rules -->|"auto-loaded"| Session
+    Plugins -->|"marketplace install"| Session
+    Docs -.->|"read by humans and AI"| Session
 
-    Plugins["**claude-code-plugins**\nCommands · skills · hooks"]
-    PerRepo["**Per-repo CLAUDE.md**\n@AGENTS.md import"]
-
-    AAI -->|"dispatch webhook"| NixAI
-    AAI -->|"@AGENTS.md"| PerRepo
-    Plugins -->|"marketplace install"| PerRepo
-    NixAI --> NixHome
+    style Rules fill:#d4e6ff,stroke:#4a90d9,color:#000
+    style Plugins fill:#fff3d4,stroke:#d4a017,color:#000
+    style Docs fill:#f0d4ff,stroke:#9b4ad9,color:#000
 ```
 
-See [`docs/diagrams.md`](docs/diagrams.md) for full architecture and session-lifecycle diagrams.
+Full rule, decision table, and update workflow: [`docs.jacobpevans.com/ai-development/repo-boundaries`](https://docs.jacobpevans.com/ai-development/repo-boundaries).
+
+For the broader Nix ecosystem context and session lifecycle diagrams, see [`docs/diagrams.md`](docs/diagrams.md).
 
 ## Prerequisites
 

--- a/docs/assets/ecosystem.mmd
+++ b/docs/assets/ecosystem.mmd
@@ -8,12 +8,15 @@ graph TD
     NixDevenv["**nix-devenv**\nProject shells\n(per-language toolchains · importable modules)"]
 
     Plugins["**claude-code-plugins**\nCommands · skills · agents · hooks"]
+    Docs["**docs**\nPublic-facing reference\n(docs.jacobpevans.com)"]
 
     PerRepo["**Per-repo CLAUDE.md**\n@AGENTS.md import"]
 
     AAI -->|"dispatch webhook\n(trigger-nix-update)"| NixAI
     AAI -->|"@AGENTS.md\ncanonical source"| PerRepo
     Plugins -->|"marketplace install\nskills · slash commands"| PerRepo
+    AAI -. "mirrored to" .-> Docs
+    Plugins -. "mirrored to" .-> Docs
 
     NixAI -->|"home.packages"| NixHome
     NixDarwin -->|"system layer"| NixHome
@@ -22,4 +25,5 @@ graph TD
     style AAI fill:#d4e6ff,stroke:#4a90d9,color:#000
     style NixAI fill:#d4ffd4,stroke:#4a9d4a,color:#000
     style Plugins fill:#fff3d4,stroke:#d4a017,color:#000
+    style Docs fill:#e8d4ff,stroke:#8a4ad9,color:#000
     style PerRepo fill:#f0d4ff,stroke:#9b4ad9,color:#000

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -3,6 +3,9 @@
 ## Ecosystem Context
 
 Where `ai-assistant-instructions` fits within the broader JacobPEvans nix-ai system.
+Companion repos: [`claude-code-plugins`](https://github.com/JacobPEvans/claude-code-plugins)
+delivers the plugins, and [`docs`](https://github.com/JacobPEvans/docs) hosts the public
+reference site at [`docs.jacobpevans.com`](https://docs.jacobpevans.com).
 
 ```mermaid
 graph TD
@@ -14,12 +17,15 @@ graph TD
     NixDevenv["**nix-devenv**\nProject shells\n(per-language toolchains · importable modules)"]
 
     Plugins["**claude-code-plugins**\nCommands · skills · agents · hooks"]
+    Docs["**docs**\nPublic-facing reference\n(docs.jacobpevans.com)"]
 
     PerRepo["**Per-repo CLAUDE.md**\n@AGENTS.md import"]
 
     AAI -->|"dispatch webhook\n(trigger-nix-update)"| NixAI
     AAI -->|"@AGENTS.md\ncanonical source"| PerRepo
     Plugins -->|"marketplace install\nskills · slash commands"| PerRepo
+    AAI -. "mirrored to" .-> Docs
+    Plugins -. "mirrored to" .-> Docs
 
     NixAI -->|"home.packages"| NixHome
     NixDarwin -->|"system layer"| NixHome
@@ -28,10 +34,14 @@ graph TD
     style AAI fill:#d4e6ff,stroke:#4a90d9,color:#000
     style NixAI fill:#d4ffd4,stroke:#4a9d4a,color:#000
     style Plugins fill:#fff3d4,stroke:#d4a017,color:#000
+    style Docs fill:#e8d4ff,stroke:#8a4ad9,color:#000
     style PerRepo fill:#f0d4ff,stroke:#9b4ad9,color:#000
 ```
 
 Source: [`docs/assets/ecosystem.mmd`](assets/ecosystem.mmd)
+
+Canonical "what lives where" rule:
+[`docs.jacobpevans.com/ai-development/repo-boundaries`](https://docs.jacobpevans.com/ai-development/repo-boundaries).
 
 ---
 


### PR DESCRIPTION
## Summary

Audit confirmed this repo has zero plugin, skill, agent, command, or hook artifacts — the migration to `claude-code-plugins` completed in earlier work. This PR codifies the boundary that audit confirmed and gives agents a clear directive about where docs live and how to update them.

- `AGENTS.md` gains a "Repo boundaries and docs" section that auto-loads into every Claude/Gemini/Copilot session across all repos. It names the three repositories, links to the canonical `docs.jacobpevans.com/ai-development/repo-boundaries` page, and lists the cross-repo update workflow (one PR per repo, `Refs: JacobPEvans/<repo>#N` footer).
- `README.md` replaces the old ecosystem mermaid with a tighter three-node boundary diagram and a paragraph pointing at the canonical docs page.
- `docs/diagrams.md` + `docs/assets/ecosystem.mmd` add the `docs` repo node so the diagram reflects all three repositories.

The companion docs PR is JacobPEvans/docs#25.

## Test plan

- [ ] `markdownlint-cli2` clean (verified locally — 0 errors on changed files)
- [ ] Mermaid in README renders on GitHub
- [ ] AGENTS.md auto-loads into a fresh session and the new boundary section is visible

Refs: JacobPEvans/docs#25