### PR TITLE
chore(rules): point at /refresh-repo --sweep and /wrap-up purge-pr

### DIFF
--- a/agentsmd/rules/tool-use.md
+++ b/agentsmd/rules/tool-use.md
@@ -17,6 +17,8 @@ description: Prefer native tools over Bash equivalents (Read/Edit/Write/Grep/Glo
 | JSON manipulation | `jq` via Bash | Python script |
 | API calls | `curl` / `gh api` | Python/curl script |
 | Multi-file git ops | Parallel Bash tool calls | Loop script |
+| Workspace sweep / abandoned branches | `/refresh-repo --sweep` | Free-form session planning that opens PRs without content checks |
+| Close PR + cleanup local state | `/wrap-up purge-pr <N>` | `gh pr close --delete-branch` alone (leaves local branch + worktree) |
 | Infrastructure config | Ansible modules, Terraform resources | Configuration script |
 | Infrastructure validation | `terraform validate`, `ansible-lint`, check modes | Validation script |
 | State queries | `terraform output`, Ansible facts | Query script |

--- a/agentsmd/rules/tool-use.md
+++ b/agentsmd/rules/tool-use.md
@@ -17,8 +17,8 @@ description: Prefer native tools over Bash equivalents (Read/Edit/Write/Grep/Glo
 | JSON manipulation | `jq` via Bash | Python script |
 | API calls | `curl` / `gh api` | Python/curl script |
 | Multi-file git ops | Parallel Bash tool calls | Loop script |
-| Workspace sweep / abandoned branches | `/refresh-repo --sweep` | Free-form session planning that opens PRs without content checks |
-| Close PR + cleanup local state | `/wrap-up purge-pr <N>` | `gh pr close --delete-branch` alone (leaves local branch + worktree) |
+| Workspace sweep / abandoned branches | `/refresh-repo --sweep` | Free-form sweep scripts |
+| Close PR + cleanup local state | `/wrap-up purge-pr <PR_NUMBER>` | `gh pr close` alone |
 | Infrastructure config | Ansible modules, Terraform resources | Configuration script |
 | Infrastructure validation | `terraform validate`, `ansible-lint`, check modes | Validation script |
 | State queries | `terraform output`, Ansible facts | Query script |


### PR DESCRIPTION
## Summary

Add two rows to the Ecosystem alternatives table in `agentsmd/rules/tool-use.md` so future AI sessions use the codified skills instead of free-form planning that opens PRs without content-equivalence checks (the failure mode that produced the 2026-05-22 ansible-splunk sweep — 8 dead PRs).

## Changes

```diff
+| Workspace sweep / abandoned branches | `/refresh-repo --sweep` | Free-form session planning that opens PRs without content checks |
+| Close PR + cleanup local state | `/wrap-up purge-pr <N>` | `gh pr close --delete-branch` alone (leaves local branch + worktree) |
```

## Companion PR

The skill extensions live in JacobPEvans/claude-code-plugins (separate PR). This rule update is the pointer that ensures the new skills actually get used.

## Test Plan

- [x] `pre-commit run --files agentsmd/rules/tool-use.md` passes locally
- [ ] After merge: future AI sessions invoking workspace cleanup should reach for `/refresh-repo --sweep` rather than improvising

## Related Issues

None — internal rule update driven by the 2026-05-22 ansible-splunk sweep retrospective.