### PR TITLE
docs: use ${GIT_HOME_PUBLIC} / ${GIT_HOME} path vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ Iron law: search first, script as last resort, never inline.
 
 ## Starting any change
 
-Run `/refresh-repo`, then create a worktree at `~/git/<repo>/<type>/<name>` on a `<type>/<name>` branch off `main`.
+Run `/refresh-repo`, then create a worktree at `${GIT_HOME_PUBLIC}/<repo>/<type>/<name>`
+(public repos) or `${GIT_HOME}/<repo>/<type>/<name>` (private) on a
+`<type>/<name>` branch off `main`.
 
 ## Scope
 

--- a/specs/git-rebase-simplification.md
+++ b/specs/git-rebase-simplification.md
@@ -92,13 +92,14 @@ New: 3 simple commands with explicit success checks
 
 ```bash
 # Step 1: Update main
-cd ~/git/REPO/main && git fetch origin && git reset --hard origin/main
+cd "${GIT_HOME_PUBLIC}/<repo>/main" && git fetch origin && git reset --hard origin/main
 
 # Step 2: Rebase and merge
-cd ~/git/REPO/BRANCH && git rebase main && cd ~/git/REPO/main && git merge --ff-only BRANCH
+cd "${GIT_HOME_PUBLIC}/<repo>/<type>/<name>" && git rebase main \
+  && cd "${GIT_HOME_PUBLIC}/<repo>/main" && git merge --ff-only <type>/<name>
 
 # Step 3: THE CRITICAL STEP - Push to origin
-cd ~/git/REPO/main && git push origin main
+cd "${GIT_HOME_PUBLIC}/<repo>/main" && git push origin main
 ```
 
 #### 3. Remove Troubleshooting from Primary Skill
@@ -274,7 +275,7 @@ git checkout main && echo "different" > shared-file && git commit -am "main chan
 ### Evidence
 
 ```bash
-$ cd ~/git/ai-assistant-instructions/worktrees/active-pull-request
+$ cd "${GIT_HOME_PUBLIC}/ai-assistant-instructions/worktrees/active-pull-request"
 $ git branch -vv
 * chore/fix-label-naming  7a61cdc  # Local branch
   main                   7a61cdc  # Same as local - merge happened


### PR DESCRIPTION
## Summary

Sweep hardcoded `~/git/...` references in AGENTS.md and specs/ to use the `${GIT_HOME_PUBLIC}` workspace variable (public repos) or `${GIT_HOME}` (private repos) introduced in nix-home v1.23.0.

## Files

- `AGENTS.md` — "Starting any change" section now distinguishes public vs private workspace roots.
- `specs/git-rebase-simplification.md` — generic `REPO` template paths plus one literal `ai-assistant-instructions/worktrees/active-pull-request` reference.

## Why

The 2026-05-25 workspace migration split repos between `${GIT_HOME}` (private + non-bare) and `${GIT_HOME_PUBLIC}` (public bare+main). AI agents reading these docs need the convention modeled correctly from the first interaction, not example paths from the pre-migration era.

## Test plan

- [x] No remaining `~/git/` refs in `*.md` / `*.sh` / `*.yml` / `*.yaml` / `*.json` (verified via grep)
- [x] Markdown linter passes (line-length wrapped at 160)
- [x] Pre-commit hooks pass

## Related

- nix-home v1.23.0 introducing `GIT_HOME` / `GIT_HOME_PUBLIC` sessionVariables
- nix-darwin doc sweep PR (sibling change in `JacobPEvans/nix-darwin#1148`)
- nix-home #265 (refactor: drop monitoring-deploy; pin orbstack-kubernetes)

Assisted-by: Claude <noreply@anthropic.com>