### PR TITLE
docs: drop workspace-path assumption from AGENTS.md + specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,7 @@ Iron law: search first, script as last resort, never inline.
 
 ## Starting any change
 
-Run `/refresh-repo`, then create a worktree at `${GIT_HOME_PUBLIC}/<repo>/<type>/<name>`
-(public repos) or `${GIT_HOME}/<repo>/<type>/<name>` (private) on a
-`<type>/<name>` branch off `main`.
+Run `/refresh-repo`, then create a `<type>/<name>` worktree off `main`. Use whatever local layout your workspace already follows.
 
 ## Scope
 

--- a/specs/git-rebase-simplification.md
+++ b/specs/git-rebase-simplification.md
@@ -91,15 +91,17 @@ Current: 7 complex bash scripts with nested subshells
 New: 3 simple commands with explicit success checks
 
 ```bash
-# Step 1: Update main
-cd "${GIT_HOME_PUBLIC}/<repo>/main" && git fetch origin && git reset --hard origin/main
+# Step 1: in the main worktree
+git fetch origin && git reset --hard origin/main
 
-# Step 2: Rebase and merge
-cd "${GIT_HOME_PUBLIC}/<repo>/<type>/<name>" && git rebase main \
-  && cd "${GIT_HOME_PUBLIC}/<repo>/main" && git merge --ff-only <type>/<name>
+# Step 2: in the feature worktree
+git rebase main
 
-# Step 3: THE CRITICAL STEP - Push to origin
-cd "${GIT_HOME_PUBLIC}/<repo>/main" && git push origin main
+# Step 3: back in the main worktree
+git merge --ff-only <type>/<name>
+
+# Step 4: THE CRITICAL STEP - still in the main worktree
+git push origin main
 ```
 
 #### 3. Remove Troubleshooting from Primary Skill
@@ -275,7 +277,7 @@ git checkout main && echo "different" > shared-file && git commit -am "main chan
 ### Evidence
 
 ```bash
-$ cd "${GIT_HOME_PUBLIC}/ai-assistant-instructions/worktrees/active-pull-request"
+$ # in the ai-assistant-instructions worktree for the active PR
 $ git branch -vv
 * chore/fix-label-naming  7a61cdc  # Local branch
   main                   7a61cdc  # Same as local - merge happened


### PR DESCRIPTION
## Summary

Follow-up to #657. That PR swapped hardcoded `~/git/...` references for `${GIT_HOME_PUBLIC}/<repo>/...`. Reviewer pushback: docs should not bake any local workspace convention into prose at all — describe what to do, not where to clone the repo.

## Changes

- **AGENTS.md "Starting any change"**: drop the dual `${GIT_HOME_PUBLIC}` / `${GIT_HOME}` template. Replace with one line: "create a `<type>/<name>` worktree off `main`. Use whatever local layout your workspace already follows."
- **specs/git-rebase-simplification.md** three-command block: drop the `cd` lines entirely. Annotate each step by worktree role (`# in the main worktree`, `# in the feature worktree`) instead of `cd "${GIT_HOME_PUBLIC}/<repo>/main"`. Evidence-block `cd` becomes a comment.

## Why this PR exists separately from #657

The user merged #657 quickly after open; the further-cleanup amend (this PR's content) didn't have time to apply pre-merge. Splitting into a follow-up keeps history clean rather than force-pushing already-merged content.

## Related

- #657 — the initial path-variable sweep this builds on
- Sibling PRs in orbstack-kubernetes, claude-code-plugins applying the same "no filesystem-layout assumptions in docs" lens
- The `${GIT_HOME}` / `${GIT_HOME_PUBLIC}` nix-home sessionVariables stay — this PR just stops referencing them in docs where they're not load-bearing

Assisted-by: Claude <noreply@anthropic.com>