### PR TITLE
fix(ci): retarget reusable-workflow uses: refs to current org homes

### DIFF
--- a/.github/workflows/ai-merge-gate.yml
+++ b/.github/workflows/ai-merge-gate.yml
@@ -3,5 +3,5 @@ on: pull_request
 permissions: read-all
 jobs:
   gate:
-    uses: JacobPEvans/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
     secrets: inherit

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   best-practices:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fail-issue.yml@main
     with:
       workflow_name: "CI Gate"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -22,7 +22,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@main
     with:
       repo_context: "AI assistant instruction files and CLAUDE.md patterns for multi-model orchestration (Claude, Gemini, Copilot)"
       ci_structure: "ci-gate.yml (alls-green gate aggregating yaml-lint, markdownlint, spellcheck, cclint, token-limits, validate-instructions checks)"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -18,5 +18,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/final-pr-review.yml@main
     secrets: inherit

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -39,7 +39,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -47,7 +47,7 @@ jobs:
   resolve-issue:
     if: false
     needs: [run-triage]
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "AI assistant instruction files and CLAUDE.md patterns for multi-model orchestration"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   next-steps:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@main
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -39,7 +39,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/agentsmd/rules/shared-workflow-org-refs.md
+++ b/agentsmd/rules/shared-workflow-org-refs.md
@@ -1,0 +1,45 @@
+---
+name: shared-workflow-org-refs
+description: In GitHub Actions uses: clauses, reference shared-CI repos by literal current owner — the don't-rewrite-on-sight redirect rule does NOT apply
+paths:
+  - ".github/workflows/*.yml"
+  - ".github/workflows/*.yaml"
+---
+
+# Shared Workflow Org References
+
+GitHub Actions reusable-workflow and action `uses:` clauses are the one place the
+"don't rewrite `JacobPEvans/*` on sight — the redirect holds" rule does NOT apply.
+
+Two hard GitHub constraints:
+
+- `uses:` cannot contain expressions or variables — the owner is always a literal.
+  `uses: ${{ vars.X }}/repo/...@ref` is rejected. No org variable can centralize it.
+- `uses:` does NOT follow repository transfer/rename redirects (by design). API, git, and the browser DO follow them; Actions does not.
+
+Consequence: when a shared-CI repo changes orgs, every consumer's `uses:` fails at parse time
+(the run shows zero jobs and "workflow was not found"). There is no runtime variable that prevents this.
+
+## Canonical homes (reference these literally)
+
+| Shared-CI repo | Current home |
+| --- | --- |
+| `ai-workflows` reusable workflows | `dryvist/ai-workflows` |
+| shared `.github` reusable workflows | `JacobPEvans-personal/.github` |
+
+These two repos are fixed homes — do not move them. Moving either is a breaking change for every consumer in the org.
+
+## Rules
+
+- In `uses:`, always reference the literal current owner above.
+- Do NOT replace a reusable-workflow call with a `gh workflow run` / checkout `vars.*` dispatcher
+  just to gain a variable: that loses required-check status, inputs/outputs, and `secrets: inherit`.
+- gh-aw `{{#import ...}}` references and compiled `*.lock.yml` files resolve at compile time
+  via the redirect — leave them to the don't-rewrite rule and gh-aw recompilation.
+
+## If a shared-CI repo must move anyway (sweep)
+
+1. `gh search code 'OLD_OWNER/REPO' --owner dryvist` (and `--owner JacobPEvans-personal`), filtered to `.github/workflows/*.yml`.
+2. Per consumer repo: swap only the `uses:` owner segment, preserving path and `@ref`; one PR per repo.
+3. Skip `*.lock.yml`, `{{#import}}`, and docs.
+4. Token tiers: dryvist repos → DRYVIST; JacobPEvans-personal repos → PRIVATE.


### PR DESCRIPTION
Part of an org-wide sweep correcting hard-coded owners in GitHub Actions `uses:` clauses.

## Root cause

GitHub Actions `uses:` clauses are special: they **cannot contain expressions/variables** (the owner is always a literal), and they **do NOT follow repository transfer/rename redirects** (by design — API, git, and the browser all follow them, but Actions does not). So when a shared-CI repo changes orgs, every consumer that hard-codes the old owner fails at parse time — the run shows zero jobs and "workflow was not found". No org variable can centralize or prevent this.

Two shared-CI repos moved:

- `ai-workflows` reusable workflows: `JacobPEvans` → `dryvist`
- shared `.github` reusable workflows: `JacobPEvans` → `JacobPEvans-personal` (account rename)

## Changes

- **14 workflow files (15 `uses:` lines):** swap only the literal owner segment, preserving the path and `@ref`.
  - `JacobPEvans/ai-workflows/` → `dryvist/ai-workflows/` (13 refs)
  - `JacobPEvans/.github/` → `JacobPEvans-personal/.github/` (2 refs: `release-please.yml`, `gh-aw-pin-refresh.yml`)
- **New rule `agentsmd/rules/shared-workflow-org-refs.md`:** documents the canonical homes and why this is the one place the "don't rewrite `JacobPEvans/*` on sight — the redirect holds" rule does NOT apply. Path-scoped to `.github/workflows/*.yml` so it auto-loads when workflow files are in context.

No `*.lock.yml` (gh-aw compiled artifacts) or `{{#import}}` references were touched — those resolve at compile time via the redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)