### PR TITLE
feat(ci): reusable secret-scan workflow + secret-scanning rule

### DIFF
--- a/.github/scripts/sensitive-denylist-scan.sh
+++ b/.github/scripts/sensitive-denylist-scan.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+################################################################################
+# sensitive-denylist-scan.sh
+#
+# Literal denylist prong of the multi-layer sensitive-value gate (Layer 3, CI).
+# Reads newline-separated POSIX-ERE regexes from the SENSITIVE_DENYLIST env var
+# (sourced in CI from the GitHub Actions secret of the same name), masks them in
+# the log, writes them to a runner-temp file, and greps them across the PR's
+# changed files. Fails the job on any match.
+#
+# Changed files are computed from the PR base/head SHAs (no third-party action),
+# so the only external dependency is the gitleaks container in the sibling job.
+#
+# Fail mode (per the SENSITIVE_DENYLIST contract):
+#   - Empty/missing denylist on a trusted (non-fork) repo -> fail CLOSED (exit 1).
+#   - Empty/missing denylist on a fork (no secret)         -> skip gracefully.
+#   - Match found                                          -> fail (exit 1).
+#   - No match                                             -> pass (exit 0).
+#
+# This script never echoes a pattern or the content of a matching line; only the
+# offending file path is reported.
+#
+# Inputs (environment):
+#   SENSITIVE_DENYLIST  - newline-separated ERE regexes (CI secret). May be empty.
+#   IS_FORK             - "true" when the PR head is a fork (secret unavailable).
+#   BASE_SHA            - PR base commit SHA (merge target).
+#   HEAD_SHA            - PR head commit SHA.
+#
+# Exit codes:
+#   0 - No match, or graceful skip on a fork.
+#   1 - Match found, or fail-closed empty denylist on a non-fork.
+################################################################################
+
+set -euo pipefail
+
+denylist="${SENSITIVE_DENYLIST:-}"
+is_fork="${IS_FORK:-false}"
+base_sha="${BASE_SHA:-}"
+head_sha="${HEAD_SHA:-HEAD}"
+
+# Mask every non-empty pattern so a value can never surface in the log, even via
+# a future debug change. GitHub honors ::add-mask:: for the rest of the job.
+while IFS= read -r line; do
+  [[ -n "$line" ]] && echo "::add-mask::$line"
+done <<< "$denylist"
+
+if [[ -z "${denylist//[$'\n\r\t ']/}" ]]; then
+  if [[ "$is_fork" == "true" ]]; then
+    echo "::notice::SENSITIVE_DENYLIST unavailable on fork PR; skipping literal denylist scan (structural gitleaks scan still runs)."
+    exit 0
+  fi
+  echo "::error::SENSITIVE_DENYLIST secret is empty or missing on a trusted repo. Failing closed — seed the secret before merging."
+  exit 1
+fi
+
+denylist_file="$(mktemp "${RUNNER_TEMP:-/tmp}/denylist.XXXXXX")"
+trap 'rm -f "$denylist_file"' EXIT
+# Drop comment and blank lines so grep -f sees only real patterns.
+printf '%s\n' "$denylist" | grep -Ev '^[[:space:]]*(#|$)' > "$denylist_file" || true
+
+if [[ ! -s "$denylist_file" ]]; then
+  if [[ "$is_fork" == "true" ]]; then
+    echo "::notice::SENSITIVE_DENYLIST contained only comments on fork PR; skipping literal scan."
+    exit 0
+  fi
+  echo "::error::SENSITIVE_DENYLIST contained no usable patterns on a trusted repo. Failing closed."
+  exit 1
+fi
+
+# Changed files between the PR base and head. --diff-filter=d skips deletions.
+mapfile -t changed_files < <(git diff --name-only --diff-filter=d "${base_sha}...${head_sha}" 2>/dev/null || true)
+
+if [[ "${#changed_files[@]}" -eq 0 ]]; then
+  echo "::notice::No changed files to scan."
+  exit 0
+fi
+
+matched=0
+for file in "${changed_files[@]}"; do
+  [[ -z "$file" ]] && continue
+  [[ -f "$file" ]] || continue
+  if grep -E -f "$denylist_file" -- "$file" >/dev/null 2>&1; then
+    echo "::error file=${file}::Sensitive value matching the private denylist found in this file. Parameterize it via Doppler/SOPS; do not commit real values."
+    matched=1
+  fi
+done
+
+if [[ "$matched" -ne 0 ]]; then
+  echo "::error::Literal denylist scan FAILED. One or more changed files contain a sensitive value. (Matching content is intentionally not printed.)"
+  exit 1
+fi
+
+echo "Literal denylist scan passed: no changed file matched the private denylist."
+exit 0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,96 @@
+# Reusable secret-scan workflow (Layer 3 of the multi-layer sensitive-value gate)
+#
+# Downstream repos call this template to run two prongs on every PR:
+#   1. Structural (value-free) gitleaks scan, driven by the caller's committed
+#      .gitleaks.toml. Always runs (incl. on forks). Uses the official gitleaks
+#      container — no gitleaks-action org-license requirement.
+#   2. Literal denylist scan: greps the private SENSITIVE_DENYLIST (a GitHub
+#      Actions secret) across the PR's changed files. Fails CLOSED if the
+#      secret is empty on a trusted repo; skips gracefully on forks.
+#
+# Consumer usage (one job in the caller's ci-gate.yml):
+#
+#   secret-scan:
+#     uses: dryvist/ai-assistant-instructions/.github/workflows/secret-scan.yml@main
+#     secrets:
+#       SENSITIVE_DENYLIST: ${{ secrets.SENSITIVE_DENYLIST }}
+#
+# The denylist contract lives in agentsmd/rules/secret-scanning.md.
+
+name: Secret Scan (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      gitleaks_config:
+        description: "Path to the caller's committed gitleaks config."
+        type: string
+        default: ".gitleaks.toml"
+      gitleaks_version:
+        description: "Pinned gitleaks container tag."
+        type: string
+        default: "v8.30.1"
+    secrets:
+      SENSITIVE_DENYLIST:
+        description: "Newline-separated ERE regexes of real sensitive values. Empty on forks."
+        required: false
+
+# Least privilege: read the code, nothing else.
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: "Structural scan (gitleaks)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Official container avoids the gitleaks-action org-license requirement.
+      - name: Run gitleaks
+        env:
+          GITLEAKS_CONFIG: ${{ inputs.gitleaks_config }}
+          GITLEAKS_VERSION: ${{ inputs.gitleaks_version }}
+        run: >
+          docker run --rm -v "$PWD:/repo" "ghcr.io/gitleaks/gitleaks:${GITLEAKS_VERSION}"
+          dir --config="/repo/${GITLEAKS_CONFIG}" --redact --no-banner --exit-code=1 /repo
+
+  denylist:
+    name: "Literal denylist scan"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # The scan script ships with this template repo, not the caller. Check it
+      # out into a private subdir so a consumer needs zero local copies.
+      - name: Checkout scan script from template repo
+        uses: actions/checkout@v6
+        with:
+          repository: dryvist/ai-assistant-instructions
+          ref: main
+          path: .secret-scan-template
+          fetch-depth: 1
+          sparse-checkout: .github/scripts/sensitive-denylist-scan.sh
+          sparse-checkout-cone-mode: false
+
+      # The script masks the denylist before any other work, computes the PR's
+      # changed files from the base/head SHAs, and greps the denylist over them.
+      - name: Scan changed files against denylist
+        env:
+          SENSITIVE_DENYLIST: ${{ secrets.SENSITIVE_DENYLIST }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .secret-scan-template/.github/scripts/sensitive-denylist-scan.sh

--- a/agentsmd/rules/secret-scanning.md
+++ b/agentsmd/rules/secret-scanning.md
@@ -1,0 +1,50 @@
+---
+name: secret-scanning
+description: Multi-layer gate blocking real homelab sensitive values from public repos. Parameterize via Doppler/SOPS; never hardcode. SENSITIVE_DENYLIST contract.
+---
+
+# Secret Scanning
+
+Real homelab-specific values — the real domain, RFC1918 subnets/IPs, Proxmox
+node names, ZFS pool names, the AWS account ID, hardware serials, person paths
+like `/Users/<name>` — must NEVER land in a public repo. Four enforcement layers
+block them before they get committed or merged.
+
+## The 4 layers
+
+| Layer | Where | Catches |
+| --- | --- | --- |
+| 0 — this rule | Every agent session | Agents parameterize sensitive values up front |
+| 1 — PreToolUse hook | `content-guards` plugin, local | Write/Edit/NotebookEdit content before it touches disk |
+| 2 — pre-commit | gitleaks + local `sensitive-denylist` hook | Staged files before commit |
+| 3 — CI template | `secret-scan.yml` reusable workflow (this repo) | PR's changed files before merge |
+| + org | GitHub org custom secret-scanning patterns | Push-protection backstop |
+
+## Two prongs (layers 2 and 3)
+
+- **Structural** — a committed, value-free `.gitleaks.toml`: PEM/SSH key blocks,
+  bare 12-digit numbers near `account`/`arn:aws`, RFC1918 literals. Patterns
+  only, safe to publish. Test fixtures use the fake `198.18`/`198.19` block.
+- **Literal** — `grep -E -f <denylist>` over changed files, catching the exact
+  real values. The list is never committed.
+
+## The `SENSITIVE_DENYLIST` contract
+
+- **Format**: newline-separated POSIX-ERE regexes (`grep -E -f` compatible).
+  `#` lines are comments; blank lines ignored. One pattern per line.
+- **Local source**: the auto-readable automation keychain (same store as
+  `GH_PAT_DRYVIST`), service name `SENSITIVE_DENYLIST` — no password prompt.
+  The user seeds it; agents must NOT write it.
+- **CI source**: the GitHub Actions secret `SENSITIVE_DENYLIST`, written by the
+  workflow to a runner-temp file and masked so it never prints in logs.
+- **Fail mode**: local hooks fail-OPEN with a stderr warning when the denylist
+  is unavailable (fresh clones / external contributors are not blocked); CI
+  fails-CLOSED when the secret is empty on a `dryvist/*` repo, and skips
+  gracefully on forks where secrets are unavailable. The structural gitleaks
+  scan always runs regardless.
+
+## Agent rule
+
+Never hardcode a sensitive value — not in source, not in a test fixture, not in
+a "wrong" example, not in a commit or PR body. Parameterize via Doppler (runtime)
+or SOPS (committed-encrypted). Build and test against the fake values above.


### PR DESCRIPTION
## What

Layers 3 + 0 of the multi-layer system that blocks real homelab values from public repos.

- **`.github/workflows/secret-scan.yml`** — reusable (`workflow_call`) template other dryvist repos invoke. Two prongs:
  - **Structural**: gitleaks via the official **container** (no `gitleaks-action` org-license needed), driven by the caller's `.gitleaks.toml`.
  - **Literal**: greps the private `SENSITIVE_DENYLIST` GH-secret over the PR's changed files. Fail-**closed** on missing secret (non-fork), graceful skip on forks, patterns `::add-mask::`ed, **path-only** reporting (never the value).
  - Consumers need zero local script copies — the scan script is sparse-checked-out from this repo.
- **`.github/scripts/sensitive-denylist-scan.sh`** — the literal-scan script.
- **`agentsmd/rules/secret-scanning.md`** — auto-loaded rule documenting the 4 layers + the `SENSITIVE_DENYLIST` contract.

## Verification
- `shellcheck` clean; YAML valid; `markdownlint` + link-check + `pre-commit` green.
- All inputs/secrets flow through `env:`; least-privilege `permissions: contents: read`.

## Sibling PRs (same effort)
- `dryvist/terraform-proxmox#339` — pre-commit hooks + CI (self-contained; migrates to this template later)
- `dryvist/claude-code-plugins#338` — Layer 1 `secret-guard` PreToolUse hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)