### PR TITLE
docs: drop custom worktree-layout instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Iron law: search first, script as last resort, never inline.
 
 ## Starting any change
 
-Run `/refresh-repo`, then create a `<type>/<name>` worktree off `main`. Use whatever local layout your workspace already follows.
+Run `/refresh-repo`, then start your change in a new worktree.
 
 ## Scope
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ First off, thanks for considering contributing to this project. It's just me her
 
 **This repo uses git worktrees for session isolation.** Always start here:
 
-1. Run `/refresh-repo` to sync main and clean stale worktrees, then create a worktree with `git worktree add`
+1. Run `/refresh-repo` to sync main, then create a worktree
 2. Make your changes in the worktree
 3. Commit your changes (`git commit -m 'feat: add some cool thing'`)
 4. Push to the branch (`git push origin feature/cool-thing`)

--- a/docs/codex-quick-start.md
+++ b/docs/codex-quick-start.md
@@ -28,7 +28,7 @@ Do not assume `~/AGENTS.md` is a guaranteed fallback. In practice, rely on the a
 
 ## Use This Every Session
 
-1. Open the correct worktree. Use `main/` or a feature worktree, not the bare repo root.
+1. Open the repo. For parallel work, use a worktree.
 2. Read the repo-local `AGENTS.md` or `CLAUDE.md` first.
 3. Ask Codex to summarize the repo contracts before editing anything.
 4. For infra work, make Codex repeat the documented wrapper command back to you before running it.


### PR DESCRIPTION
## What

Removes the custom bare-repo + `<type>/<name>` worktree wording. The instructions now just say "use/create a worktree" and let each AI tool handle creation natively.

- `AGENTS.md` — "Starting any change": `…then start your change in a new worktree.`
- `docs/codex-quick-start.md` — drops the `main/` / "bare repo root" step.
- `CONTRIBUTING.md` — step 1 drops the `git worktree add` spelling.

## Why

First instruction-layer PR of the worktree-migration effort (#671). Explicit worktree CLI commands (`git worktree add`, `claude --worktree`, picker steps) actively suppress the AI tools' native worktree handling, so we delete them rather than replace them with more detail.

Refs: dryvist/ai-assistant-instructions#671

🤖 Generated with [Claude Code](https://claude.com/claude-code)