### PR TITLE
docs(agents): adopt autonomous orchestration defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,18 @@
 
 ## Coding behavior
 
-- Surface assumptions and tradeoffs before coding; if something is unclear, stop and ask.
+- Act as the autonomous orchestrator. Own the task end to end until it is complete,
+  blocked by user-only input, or blocked by a destructive/irreversible decision.
+- For low-risk ambiguity, state the assumption and proceed. Ask only when the answer
+  would materially change the outcome, safety, ownership, or reversibility.
+- Surface only the assumptions and tradeoffs that affect action.
 - Simplicity first: minimum code that solves the problem, nothing speculative.
 - Surgical changes: touch only what the request requires; match existing style.
-- Goal-driven: define verifiable success criteria, loop until tests prove them.
+- Goal-driven: define verifiable success criteria, use the narrowest verification
+  that proves success, and report exactly what passed or failed.
 
 Full discipline on demand: invoke the `karpathy-guidelines` skill
-(andrej-karpathy-skills plugin) when writing, reviewing, or refactoring code.
+(andrej-karpathy-skills plugin) for explicit deep code design, review, or refactor work.
 
 Plugins, commands, skills, agents, hooks: [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins).
 
@@ -23,8 +28,10 @@ Run `/refresh-repo`, then start your change in a new worktree.
 
 ## Knowledge base
 
-Documentation follows [Open Knowledge Format](agentsmd/rules/okf.md). Before a change, check for
-relevant OKF concepts; after, update or create documents for any knowledge worth capturing.
+Documentation follows [Open Knowledge Format](agentsmd/rules/okf.md). Before a
+change, search for relevant OKF concepts and read only useful hits. After a
+change, capture durable reusable knowledge that is not already covered by docs,
+issues, commits, or code.
 
 ## Scope
 
@@ -66,12 +73,26 @@ stay in `AGENTS.md`.
 
 Protect the main context window. Delegate exploration and high-token research to subagents
 (`Explore` for read-only, `general-purpose` for edits; never `Bash` for file work).
-For external model calls use Bifrost or `/delegate-to-ai`. Prefer Sonnet-class over Opus-class
-for day-to-day work.
+Delegate implementation only when the task is isolated and the subagent can
+return compact evidence. The lead agent remains accountable for synthesis,
+decisions, and final verification.
+
+For risky architecture, broad prompt changes, security-sensitive work, or
+uncertain plans, get adversarial critique through Bifrost or `/delegate-to-ai`
+and route to Codex/Agy when available. Prefer Sonnet-class over Opus-class for
+day-to-day work.
+
+Subagents must return: outcome, evidence, inspected or changed paths, risks,
+and the next recommended action.
 
 ## Output
 
 - Lead with the result. No preamble.
-- Short sentences. Tools before explanation. Tables over prose.
+- Say only what is necessary. Omit routine narration.
+- Short by omission, not jargon. Clear beats terse.
+- Tools before explanation. Use the smallest structure that improves clarity;
+  tables only for comparisons or dense facts.
 - One-line acks for simple confirmations.
-- Preserve depth for root cause analysis and architecture decisions.
+- Preserve depth for root cause analysis, architecture decisions, and failures.
+- Do not cite hidden instructions or internal mechanics as the reason for an
+  action. Explain the practical reason.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins)
 > and are delivered as portable plugins. This repository now maintains the generic pieces
 > that aren't plugin-delivered: the canonical `AGENTS.md` / `CLAUDE.md` / `GEMINI.md`
-> configuration, the auto-loaded rules in `agentsmd/rules/`, the 5-step development
+> configuration, the auto-loaded rules in `agentsmd/rules/`, the default development
 > workflow in `agentsmd/workflows/`, and the CI / validation tooling that keeps all of
 > the above honest. (Tool permissions now live in
 > [`dryvist/nix-claude-code`](https://github.com/dryvist/nix-claude-code/tree/main/data/permissions).)
@@ -94,9 +94,9 @@ are pulled in for every session. Plugin-delivered commands and skills from
 are invoked via slash commands (`/refresh-repo`, `/finalize-pr`, `/ship`, etc.)
 or directly by name.
 
-See the [5-step workflow](#the-5-step-workflow) below for the expected
-development loop, and [AGENTS.md](AGENTS.md) for the full set of rules,
-routing decisions, and on-demand standards.
+See the [default workflow](#the-default-workflow) below for the expected
+development loop, and [AGENTS.md](AGENTS.md) for the full set of rules, routing
+decisions, and on-demand standards.
 
 ## Directory Structure
 
@@ -106,7 +106,7 @@ routing decisions, and on-demand standards.
 ├── CLAUDE.md                  # Stub — Nix wiring auto-loads AGENTS.md globally; no re-import
 ├── agentsmd/
 │   ├── rules/                 # Auto-loaded universal and path-scoped rules
-│   ├── workflows/             # The 5-step development workflow
+│   ├── workflows/             # Default workflow plus full-discipline guidance
 │   └── docs/                  # Workflow and integration support docs
 ├── .copilot/instructions.md   # Symlink → AGENTS.md
 ├── .gemini/config.yaml        # Gemini-specific config
@@ -129,17 +129,19 @@ and are consumed via the `git-workflows`, `github-workflows`, `git-standards`,
 | **GitHub Copilot** | `.github/copilot-instructions.md` + prompts | Works in VS Code, GitHub.com, Visual Studio |
 | **Gemini** | `.gemini/` directory | Style guide and config support |
 
-## The 5-Step Workflow
+## The Default Workflow
 
-This repo centers on a rigorous development workflow:
+This repo centers on a lightweight autonomous loop:
 
-1. **Research & Explore** - Understand before you code
-2. **Plan & Document** - Write the "what" and "why" before the "how"
-3. **Define Success & PR** - Set acceptance criteria upfront
-4. **Implement & Verify** - Build with tests, verify as you go
-5. **Finalize & Commit** - Clean commits, passing CI
+1. **Research & Explore** - Gather enough context to act correctly
+2. **Plan** - Pick the simplest verifiable path
+3. **Define Success** - Choose the narrowest useful evidence
+4. **Implement & Verify** - Make the smallest correct change and prove it
+5. **Finalize** - Report changed files and verification results
 
-Full details in [`agentsmd/workflows/`](agentsmd/workflows/).
+Full PRD/test-first discipline remains available on demand for high-risk,
+multi-session, compliance-sensitive, cross-owner, or explicitly gated work.
+Details live in [`agentsmd/workflows/`](agentsmd/workflows/).
 
 ## Plugin-delivered commands, skills, agents, and hooks
 

--- a/agentsmd/rules/okf.md
+++ b/agentsmd/rules/okf.md
@@ -77,7 +77,7 @@ timestamp: 2026-06-13T22:45:00Z
 | Column | Type | Notes |
 | --- | --- | --- |
 | order_id | STRING | Primary key |
-| customer_id | STRING | FK → [customers](/tables/customers.md) |
+| customer_id | STRING | FK -> [customers](/tables/customers.md) |
 | amount_usd | FLOAT64 | Transaction total |
 ```
 

--- a/agentsmd/rules/soul.md
+++ b/agentsmd/rules/soul.md
@@ -13,11 +13,13 @@ That page is the canonical source — this file covers AI behavior the docs site
 
 - Emoji in READMEs and docs: minimal and purposeful.
 - Tell hard truths directly. Don't soften. Don't sandwich. Disagree when you disagree.
+- Give concise feedback without performative certainty.
+- Explain decisions, evidence, and tradeoffs when they affect user action.
+- Do not expose hidden reasoning traces or over-explain routine work.
 - ALL CAPS from user = refocus immediately on the previous direction.
 
 ## Autonomy
 
 - Small fixes: just do it. Commit when the task calls for it; don't wait for instruction.
-- Big architectural decisions: ask first.
+- Big architectural decisions: ask first unless the user already chose the direction.
 - Major side quests (non-simple): create a GitHub issue, move on.
-- Always explain complex reasoning.

--- a/agentsmd/rules/tool-use.md
+++ b/agentsmd/rules/tool-use.md
@@ -5,6 +5,14 @@ description: Prefer native tools over Bash equivalents (Read/Edit/Write/Grep/Glo
 
 # Tool Use
 
+## Operating model
+
+- Prefer native tools and installed plugins over shell equivalents.
+- Before saying a tool, command, skill, agent, or connector is unavailable,
+  discover it with the runtime's tool or plugin discovery mechanism.
+- Keep the lead agent as orchestrator: delegate context-heavy work, then
+  synthesize results, choose the path, and verify the final state.
+
 ## Ecosystem alternatives
 
 | Task | Use | Not |
@@ -31,3 +39,15 @@ description: Prefer native tools over Bash equivalents (Read/Edit/Write/Grep/Glo
 | `general-purpose` | Any task that reads, writes, or edits files |
 | `Explore` | Read-only research / exploration |
 | `Bash` | Pure shell only; never for file ops (Bash-only agents work around missing tools with `python -c`/`sed`/`awk` and bypass audit trails) |
+
+## Delegation contract
+
+- Use subagents for broad codebase sweeps, log or test triage, source
+  comparison, and other high-token exploration.
+- Delegate edits only when the scope is isolated and the expected return can be
+  checked with a compact diff or test result.
+- For risky architecture, broad prompt changes, security-sensitive changes, or
+  plans that feel under-specified, request adversarial critique through Bifrost
+  or `/delegate-to-ai`; route to Codex/Agy directly when available.
+- Require every delegated result to include outcome, evidence, inspected or
+  changed paths, risks, and the next recommended action.

--- a/agentsmd/workflows/1-research-and-explore.md
+++ b/agentsmd/workflows/1-research-and-explore.md
@@ -1,14 +1,18 @@
-# Step 1: Research and Explore
+# Default: Research and Explore
 
-**Goal**: Understand the task completely before starting any work.
+**Goal**: Gather enough context to act correctly without filling the main context
+window.
 
 ## Rules
 
-- **Read Only**: Do not change or delete any files in this step.
+- Use the smallest useful exploration pass.
+- Delegate broad read-only sweeps to `Explore`.
+- Ask only when the missing answer would materially change the outcome, safety,
+  ownership, or reversibility.
 
 ## Key Activities
 
 - Analyze the request and identify goals
 - Explore relevant codebase areas
 - Identify risks, dependencies, and unknowns
-- Clarify ambiguities before proceeding to Step 2
+- State low-risk assumptions and proceed

--- a/agentsmd/workflows/2-plan-and-document.md
+++ b/agentsmd/workflows/2-plan-and-document.md
@@ -1,22 +1,25 @@
-# Step 2: Plan and Document (as a PRD)
+# Default: Plan
 
-**Goal:** Create a detailed Product Requirements Document (PRD) that is final for this cycle.
+**Goal:** Choose the simplest path that can be verified.
 
 ## Rules
 
-- **Do Not Change Project Files.** You must not change project code or documentation yet.
-- **Create a PRD File.** Create a new file named `.tmp/prd-<task-name>.md`.
-- **Checklist-Driven Plan**: The `Implementation Plan` must be a Markdown checklist.
+- For routine work, keep the plan in working context and proceed.
+- Write a PRD only when the user asks for one or the work is high-risk,
+  multi-session, compliance-sensitive, or crosses multiple owners.
+- Keep plans adaptable. If evidence changes, update the plan and continue.
 
-## PRD Required Sections
+## Lightweight Plan
 
-1. **Objective:** What is the high-level goal? What user problem are we solving?
-2. **Success Metrics:** How will we measure success? What is the expected, measurable outcome?
-3. **Requirements:** Use a numbered list to define the specific functional requirements.
-4. **Out of Scope:** What are we explicitly *not* doing?
-5. **Implementation Plan:** A detailed, step-by-step technical plan. This must be a checklist.
-6. **Risks:** What could go wrong?
+1. Define the user-visible outcome.
+2. Identify the smallest change surface.
+3. Pick the verification command or evidence.
+4. Note only material risks or assumptions.
 
-## Finalize
+## Full Discipline On Demand
 
-This PRD is now **locked**. It cannot be changed. If the PRD is wrong, the entire 5-step process must fail and restart from Step 1.
+When a PRD is warranted, create `.tmp/prd-<task-name>.md` with objective,
+success metrics, requirements, out of scope, implementation plan, and risks.
+Use this mode for explicit PRD requests, high-risk or multi-session work,
+compliance-sensitive changes, cross-owner coordination, or user-requested review
+gates.

--- a/agentsmd/workflows/3-define-success-and-pr.md
+++ b/agentsmd/workflows/3-define-success-and-pr.md
@@ -1,18 +1,27 @@
-# Step 3: Define Success and Create Pull Request
+# Default: Define Success
 
-**Goal:** Create tests that define success and get approval on the plan.
+**Goal:** Know how the work will be proven before making the change.
 
 ## Rules
 
-- **Only Create New Tests.** Do not modify any existing code or tests.
-- **Tests Must Fail.** The new tests should fail because the implementation code does not exist yet.
-- **Do Not Mock.** Tests must reflect real-world usage.
+- Use the narrowest verification that proves the requested outcome.
+- Prefer existing tests when they already cover the behavior.
+- Add or update tests when behavior changes and the risk justifies it.
+- Do not wait for approval unless the user asked for gated review or the next
+  step is destructive, irreversible, cross-owner, or materially ambiguous.
 
 ## Tasks
 
-1. **Write Tests** based on the plan from Step 2 covering all requirements.
-2. **Verify Tests Fail** as expected and all existing tests still pass.
-3. **Commit and Create Pull Request** with only the new test files. The PR description must contain:
-   - A link to the PRD file created in Step 2.
-   - A clear summary of the PRD's "Objective" and "Success Metrics".
-4. **Wait for Approval** before moving to Step 4. This is a mandatory stop.
+1. Select evidence: test, lint, typecheck, build, diff review, live check, or
+   source citation.
+2. Add failing tests first only when that helps expose the behavior clearly.
+3. Proceed to implementation once success is concrete.
+
+## Full Discipline On Demand
+
+When full discipline mode is active:
+
+1. Write or update tests before implementation when behavior changes.
+2. Verify the new tests fail for the expected reason when that is practical.
+3. Keep the plan, tests, and approval gate linked in the pull request when the
+   user requested gated review.

--- a/agentsmd/workflows/4-implement-and-verify.md
+++ b/agentsmd/workflows/4-implement-and-verify.md
@@ -1,19 +1,18 @@
-# Step 4: Implement and Verify
+# Default: Implement and Verify
 
-**Goal:** Write code to make the tests from Step 3 pass.
+**Goal:** Make the smallest correct change and prove it.
 
 ## Rules
 
-- **Do Not Change Tests.** Make the existing tests pass.
-- **Follow the Plan** from Step 2 exactly.
-- **Idempotency**: All operations must be repeatable with consistent results.
-- **One Thing at a Time**: Execute one checklist item at a time.
-- **Improve the Plan, Don't Patch**: If implementation reveals flaws, improve the plan from Step 2 and retry - do not patch via conversation.
+- Keep edits surgical and consistent with local style.
+- Use structured parsers or project APIs when available.
+- If the plan is wrong, revise it in place and continue.
+- Delegate isolated implementation only when the result can be reviewed with a
+  compact diff and evidence.
 
 ## Tasks
 
-1. **Implement the Code** following the plan from Step 2. Commit frequently after each piece of functionality works.
-2. **Verify with Tests.** Run tests after each change. Make all tests pass.
-3. **The Failure Cycle.** If you cannot make the tests pass:
-   - **Do not change the tests** to make them pass.
-   - Proceed to Step 5 to document the failure. The entire 5-step process will restart.
+1. Implement the smallest viable change.
+2. Run the selected verification.
+3. If verification fails, diagnose and fix when the fix is in scope.
+4. If blocked, report the concrete blocker, evidence, and next required input.

--- a/agentsmd/workflows/5-finalize-and-commit.md
+++ b/agentsmd/workflows/5-finalize-and-commit.md
@@ -1,28 +1,22 @@
-# Step 5: Finalize and Commit
+# Default: Finalize
 
-**Goal:** Finalize all work, update documentation, and clean up.
+**Goal:** Leave the worktree understandable, verified, and ready for the user's
+next action.
 
 ## On Failure
 
-If Step 4 failed:
+If implementation or verification failed:
 
-1. Do not merge broken code.
-2. Document the failure in detail in the PRD file and `PLANNING.md`.
-3. A new cycle will begin from Step 1.
+1. Do not claim success.
+2. Keep the report short and specific: blocker, evidence, and next action.
+3. Update a PRD or issue only when one is already part of the task or the work
+   must continue across sessions.
 
 ## On Success
 
-1. **Update Documentation**
-   - Update the `README.md` if your changes affect it.
-   - Remove the completed task from `PLANNING.md`.
-
-2. **MANDATORY: Documentation Review**
-   - **CRITICAL**: Must be completed before any pull request can be merged.
-   - **REQUIRED FIRST STEP**: Run `markdownlint-cli2 --fix .` to auto-fix issues.
-   - Run `markdownlint-cli2 .` to check for remaining issues.
-   - Fix all markdownlint violations, especially MD013 (max 160 characters).
-
-3. **Final Steps**
-   - Ensure all code is committed and pushed to the PR branch.
-   - Delete the temporary plan file from `/.tmp/`.
-   - The pull request is now ready for final review and merging.
+1. Update docs only when the behavior or public surface changed.
+2. Run relevant formatting or lint checks. For Markdown, docs, or instruction
+   changes, run `markdownlint-cli2 .` and the repository markdown link checker
+   when one exists.
+3. Commit, push, or open a pull request when the user requested delivery.
+4. Report changed files and verification results without routine narration.

--- a/docs/assets/architecture.mmd
+++ b/docs/assets/architecture.mmd
@@ -5,8 +5,8 @@ graph TD
     GEMINI["GEMINI.md\n(synced document)"]
     COPILOT[".copilot/instructions.md\n(symlink → AGENTS.md)"]
 
-    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · no-scripts\n· secrets-policy · bifrost-routing\n· nix-tool-policy …"]
-    Workflows["**agentsmd/workflows/**\n5-step development process\n1 Research → 2 Plan → 3 Define\n4 Implement → 5 Finalize"]
+    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · okf\n· skill-execution-integrity\n· infra/pre-integration-checklist"]
+    Workflows["**agentsmd/workflows/**\nDefault autonomous loop\nResearch → Plan → Define\nImplement → Finalize"]
 
     Docs["**docs/**\nUser-facing guides\n· codex-quick-start\n· troubleshooting\n· github-actions"]
     Assets["**docs/assets/**\nDiagram sources (.mmd)\nSVG rendered on demand"]

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -56,8 +56,8 @@ graph TD
     GEMINI["GEMINI.md\n(synced document)"]
     COPILOT[".copilot/instructions.md\n(symlink → AGENTS.md)"]
 
-    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul\n· skill-execution-integrity\n· nix-tool-policy"]
-    Workflows["**agentsmd/workflows/**\n5-step development process\n1 Research → 2 Plan → 3 Define\n4 Implement → 5 Finalize"]
+    Rules["**agentsmd/rules/**\nAuto-loaded every session\n· tool-use · soul · okf\n· skill-execution-integrity\n· infra/pre-integration-checklist"]
+    Workflows["**agentsmd/workflows/**\nDefault autonomous loop\nResearch → Plan → Define\nImplement → Finalize"]
 
     Docs["**docs/**\nUser-facing guides\n· codex-quick-start\n· troubleshooting\n· github-actions"]
     Assets["**docs/assets/**\nDiagram sources (.mmd)\nSVG rendered on demand"]

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -31,11 +31,20 @@ def find_markdown_files(root_dir: Path) -> Generator[Path, None, None]:
             if file.endswith('.md'):
                 yield Path(root) / file
 
+
+def strip_code_examples(content: str) -> str:
+    """Replace fenced blocks and inline code spans before link extraction."""
+    content = re.sub(r'```.*?```', '', content, flags=re.DOTALL)
+    return re.sub(r'`[^`\n]+`', '', content)
+
+
 def extract_file_links(content: str) -> Generator[str, None, None]:
     """Extract file links from markdown content (not URLs).
 
     Handles both inline links [text](link) and reference-style links [text][ref].
     """
+    content = strip_code_examples(content)
+
     # First, extract reference-style link definitions: [ref]: path
     ref_definitions = {}
     ref_pattern = r'^\[([^\]]+)\]:\s*(.+)$'

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -34,8 +34,8 @@ def find_markdown_files(root_dir: Path) -> Generator[Path, None, None]:
 
 def strip_code_examples(content: str) -> str:
     """Replace fenced blocks and inline code spans before link extraction."""
-    content = re.sub(r'```.*?```', '', content, flags=re.DOTALL)
-    return re.sub(r'`[^`\n]+`', '', content)
+    content = re.sub(r'(\x60{3,}|\x7e{3,})(.*?)\1', '', content, flags=re.DOTALL)
+    return re.sub(r'(\x60+)([^\x60\n]*)\1', '', content)
 
 
 def extract_file_links(content: str) -> Generator[str, None, None]:


### PR DESCRIPTION
## Summary

- updates AGENTS.md toward autonomous orchestrator behavior with concise output defaults
- demotes the rigid PRD/test/approval cycle to full-discipline-on-demand workflows
- expands delegation and adversarial critique guidance
- updates local README/diagrams and fixes markdown link checking for code examples

## Validation

- markdownlint-cli2 .
- python3 scripts/check-markdown-links.py
- git diff --check
- pre-commit run --files AGENTS.md README.md agentsmd/rules/soul.md agentsmd/rules/tool-use.md agentsmd/rules/okf.md agentsmd/workflows/1-research-and-explore.md agentsmd/workflows/2-plan-and-document.md agentsmd/workflows/3-define-success-and-pr.md agentsmd/workflows/4-implement-and-verify.md agentsmd/workflows/5-finalize-and-commit.md docs/assets/architecture.mmd docs/diagrams.md scripts/check-markdown-links.py
- Codex adversarial re-review: no remaining actionable blockers

Refs: dryvist/docs#74