### PR TITLE
docs(agents): add OKF compliance directive to knowledge base section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ Run `/refresh-repo`, then start your change in a new worktree.
 
 ## Knowledge base
 
-Documentation follows [Open Knowledge Format](agentsmd/rules/okf.md). Before a
+Documentation follows [Open Knowledge Format](agentsmd/rules/okf.md) — maintain OKF
+compliance and best practices when authoring or editing knowledge documents. Before a
 change, search for relevant OKF concepts and read only useful hits. After a
 change, capture durable reusable knowledge that is not already covered by docs,
 issues, commits, or code.


### PR DESCRIPTION
## Summary

- Extends the "Knowledge base" section in `AGENTS.md` with an explicit OKF compliance mandate: "maintain OKF compliance and best practices when authoring or editing knowledge documents"
- No structural changes — single sentence addition to the existing paragraph
- `agentsmd/rules/okf.md` already contains the full OKF spec (added in #690); this change makes the behavioral directive explicit rather than implied

## Context

The `status-scaffold-okf-standardization` session standardized OKF across the obsidian-visicore vault. The vault's `.claude/rules/okf-conventions.md` is correctly vault-scoped and stays there. The only missing piece in this repo was an explicit "always maintain compliance" blurb in AGENTS.md.

## Test plan

- [ ] Confirm `agentsmd/rules/okf.md` is unchanged
- [ ] Confirm AGENTS.md "Knowledge base" section reads naturally with the new sentence

🤖 Generated with [Claude Code](https://claude.com/claude-code)