### PR TITLE
docs(readme): make standalone — drop cross-repo narrative, link the hub

### DIFF
--- a/.readme-validator.yaml
+++ b/.readme-validator.yaml
@@ -1,5 +1,9 @@
 # README Validator Configuration
 # Excludes internal documentation READMEs that aren't project root READMEs
 
+required_sections:
+  - Installation
+  - Usage
+
 exclude_paths:
   - "agentsmd/**/README.md"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
 # AI Assistant Instructions
 
 > Teaching AI assistants how to help you better. Yes, it's AI instructions written with AI assistance. We've come full circle.
->
-> **Scope**: Commands, skills, agents, and hooks have been migrated to
-> [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins)
-> and are delivered as portable plugins. This repository now maintains the generic pieces
-> that aren't plugin-delivered: the canonical `AGENTS.md` / `CLAUDE.md` / `GEMINI.md`
-> configuration, the auto-loaded rules in `agentsmd/rules/`, the default development
-> workflow in `agentsmd/workflows/`, and the CI / validation tooling that keeps all of
-> the above honest. (Tool permissions now live in
-> [`dryvist/nix-claude-code`](https://github.com/dryvist/nix-claude-code/tree/main/data/permissions).)
 
 [![License][license-badge]][license-url]
 [![Markdown Lint][markdownlint-badge]][markdownlint-url]
@@ -22,32 +13,16 @@ Drop these into your projects and get consistent, high-quality AI assistance acr
 
 Think of it as a style guide, but for your AI pair programmer.
 
-### Repo boundaries
+This repository maintains the generic, plugin-independent pieces:
 
-The AI configuration layer is split across three repositories. This repo owns the rules.
-[`claude-code-plugins`](https://github.com/JacobPEvans/claude-code-plugins) owns commands, skills, agents, and hooks.
-[`docs`](https://github.com/JacobPEvans/docs) owns the public-facing reference site at
-[`docs.jacobpevans.com`](https://docs.jacobpevans.com).
+- The canonical `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` configuration
+- The auto-loaded rules in `agentsmd/rules/`
+- The default development workflow in `agentsmd/workflows/`
+- The CI / validation tooling that keeps all of the above honest
 
-```mermaid
-graph LR
-    Rules["**ai-assistant-instructions**<br/>rules · workflows · CI tooling"]
-    Plugins["**claude-code-plugins**<br/>commands · skills · agents · hooks"]
-    Docs["**docs**<br/>public-facing reference"]
-    Session(("Developer session"))
-
-    Rules -->|"auto-loaded"| Session
-    Plugins -->|"marketplace install"| Session
-    Docs -.->|"read by humans and AI"| Session
-
-    style Rules fill:#d4e6ff,stroke:#4a90d9,color:#000
-    style Plugins fill:#fff3d4,stroke:#d4a017,color:#000
-    style Docs fill:#e8d4ff,stroke:#8a4ad9,color:#000
-```
-
-Full rule, decision table, and update workflow: [`docs.jacobpevans.com/ai-development/repo-boundaries`](https://docs.jacobpevans.com/ai-development/repo-boundaries).
-
-For the broader Nix ecosystem context and session lifecycle diagrams, see [`docs/diagrams.md`](docs/diagrams.md).
+Boundaries between this and the other AI-configuration layers (what lives here
+versus what is plugin-delivered or published to the docs site) are documented at
+[`docs.jacobpevans.com/ai-development/repo-boundaries`](https://docs.jacobpevans.com/ai-development/repo-boundaries).
 
 ## Prerequisites
 
@@ -73,26 +48,23 @@ cp -r ai-assistant-instructions/agentsmd/rules your-project/agentsmd/
 cd your-project
 ln -sf AGENTS.md CLAUDE.md
 ln -sf AGENTS.md GEMINI.md
-
-# 4. Install the plugins from JacobPEvans/claude-code-plugins
-#    (commands, skills, agents, and hooks live there, not here)
-claude marketplace add JacobPEvans/claude-code-plugins
-claude plugin install git-workflows github-workflows git-standards
-
-# 5. Verify setup
-claude doctor
 ```
 
 Or just browse the [documentation](docs/) and cherry-pick what you need.
+
+### Slash commands and skills
+
+This repository ships configuration only — no slash commands, skills, agents, or
+hooks. Those are delivered as a separate, installable Claude Code plugin
+marketplace. Once the marketplace is added and the plugins are enabled, commands
+referenced by the workflow (for example `/refresh-repo`, `/finalize-pr`, `/ship`)
+become available alongside the configuration in this repo.
 
 ## Usage
 
 Once installed, the AI assistants read `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`
 automatically at session start, and the auto-loaded rules in `agentsmd/rules/`
-are pulled in for every session. Plugin-delivered commands and skills from
-[JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins)
-are invoked via slash commands (`/refresh-repo`, `/finalize-pr`, `/ship`, etc.)
-or directly by name.
+are pulled in for every session.
 
 See the [default workflow](#the-default-workflow) below for the expected
 development loop, and [AGENTS.md](AGENTS.md) for the full set of rules, routing
@@ -113,13 +85,6 @@ decisions, and on-demand standards.
 ├── scripts/                   # Validation helpers (token limits, links)
 └── .github/workflows/         # CI gates (markdown, spellcheck, link check, CodeQL, release-please)
 ```
-
-Claude-Code plugins (commands, skills, agents, hooks) live in
-[JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins)
-and are consumed via the `git-workflows`, `github-workflows`, `git-standards`,
-`code-standards`, `infra-standards`, `project-standards`, `ai-delegation`,
-`config-management`, `content-guards`, `git-guards`, `script-guards`,
-`codeql-resolver`, and `session-analytics` plugins (among others).
 
 ## Supported AI Assistants
 
@@ -143,30 +108,6 @@ Full PRD/test-first discipline remains available on demand for high-risk,
 multi-session, compliance-sensitive, cross-owner, or explicitly gated work.
 Details live in [`agentsmd/workflows/`](agentsmd/workflows/).
 
-## Plugin-delivered commands, skills, agents, and hooks
-
-All slash commands, skills, agents, and hooks previously listed in this README
-now ship as plugins in
-[JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins).
-Install the marketplace and enable the plugins you need:
-
-| Plugin | Provides |
-| --- | --- |
-| `git-workflows` | `/refresh-repo`, `/sync-main`, `/rebase-pr`, `/troubleshoot-*` |
-| `github-workflows` | `/finalize-pr`, `/squash-merge-pr`, `/ship`, `/resolve-pr-threads`, `/shape-issues`, `/trigger-ai-reviews` |
-| `git-standards` | `/git-workflow-standards`, `/pr-standards` |
-| `code-standards` | `/code-quality-standards`, `/review-standards` |
-| `infra-standards` | `/infrastructure-standards` |
-| `project-standards` | `/agentsmd-authoring`, `/workspace-standards`, `/skills-registry` |
-| `ai-delegation` | `/delegate-to-ai`, `/auto-maintain` |
-| `config-management` | `/sync-permissions`, `/quick-add-permission` |
-| `codeql-resolver` | `/resolve-codeql` + specialist agents |
-| `session-analytics` | `/token-breakdown` |
-| `content-guards`, `git-guards`, `script-guards`, `pr-lifecycle`, `pal-health`, `process-cleanup` | PreToolUse / PostToolUse / Stop hooks — invoked automatically |
-
-See [AGENTS.md](AGENTS.md) for the full on-demand standards table and the
-auto-loaded rules reference.
-
 ## Core Concepts
 
 The documentation covers:
@@ -174,24 +115,17 @@ The documentation covers:
 - **Code Standards** - Consistency across languages
 - **Documentation Standards** - AI-friendly markdown
 - **Infrastructure Standards** - Terraform/Terragrunt patterns
-- **Permission System** - Where AI tool permissions now live (nix-claude-code)
 - **DRY Principle** - Why everything symlinks to one place
 - **Memory Bank** - Maintaining AI context across sessions
 - **Remote Commit Workflow** - Making commits via GitHub API without local clone
 
 Browse [`agentsmd/rules/`](agentsmd/rules/) and [`agentsmd/docs/`](agentsmd/docs/).
 
-**Advanced**: Tool permissions are no longer defined in this repo. They live in
-[`dryvist/nix-claude-code`](https://github.com/dryvist/nix-claude-code/tree/main/data/permissions),
-which `nix-ai` renders into Claude / Codex / Gemini / Copilot settings. See
-[`agentsmd/docs/permission-system.md`](agentsmd/docs/permission-system.md) for
-the pointer.
-
 ## Need Help?
 
 - [Codex Quick Start](docs/codex-quick-start.md) - repo analysis, prompt patterns, and Codex parity backlog
-- 📖 [Documentation Home](docs/) - Getting started guides and references
-- 🐛 [Issues](https://github.com/JacobPEvans/ai-assistant-instructions/issues) - Report bugs or request features
+- [Documentation Home](docs/) - Getting started guides and references
+- [Issues](https://github.com/JacobPEvans/ai-assistant-instructions/issues) - Report bugs or request features
 
 ## Contributing
 
@@ -206,13 +140,13 @@ Found a vulnerability? Please report it responsibly. See [SECURITY.md](SECURITY.
 
 [Apache 2.0](LICENSE) - Use it, modify it, just keep the attribution.
 
----
-
-*Built by a human, refined by AI, used by both.*
-
 [license-badge]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
 [license-url]: LICENSE
 [markdownlint-badge]: https://github.com/JacobPEvans/ai-assistant-instructions/actions/workflows/markdownlint.yml/badge.svg
 [markdownlint-url]: https://github.com/JacobPEvans/ai-assistant-instructions/actions/workflows/markdownlint.yml
 [precommit-badge]: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit
 [precommit-url]: https://github.com/pre-commit/pre-commit
+
+---
+
+> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) — see how it all fits together.


### PR DESCRIPTION
## Summary

Rewrites the root `README.md` to the standalone repo-README standard: it now
describes **only this repository**, and the cross-repo story is routed to the
docs hub instead of being duplicated here.

**Removed (pure cross-repo narrative):**

- The **"Repo boundaries"** section — including the repo-relationship **mermaid
  diagram** and the sibling descriptions of `claude-code-plugins` and `docs`.
- All cross-repo links / narrative: `claude-code-plugins`, `nix-claude-code`,
  the "broader Nix ecosystem" `docs/diagrams.md` pointer, and the
  plugin-permission pointers in *Core Concepts* / *Advanced*.
- The **"Plugin-delivered commands, skills, agents, and hooks"** table, which
  enumerated another repo's contents.

**Kept / reframed:**

- The single `docs.jacobpevans.com/ai-development/repo-boundaries` pointer
  routes readers to the canonical boundary map (the right move — keep it).
- Genuine dependencies are now **contracts, not names**: AI tools read
  `AGENTS.md` and the symlinked `CLAUDE.md`/`GEMINI.md`; slash commands come
  from a separately-installed plugin marketplace — described by shape, no
  sibling repo named.
- Headings normalized to the standard shape; **`## Installation`** and
  **`## Usage`** both present and in order.
- A single ecosystem footer link added once at the very end.

Also makes `.readme-validator.yaml`'s root-README contract explicit: adds
`required_sections` (`Installation`, `Usage`) as **unquoted** scalars so the
simple YAML parser matches the headings (quoted scalars fail the lowercase
exact-match check). Existing `exclude_paths` is unchanged (UPDATE, not delete).

Edits `README.md` and `.readme-validator.yaml` only — `agentsmd/` is untouched
(that's PR #695's scope). Branch name deliberately differs from #695 to avoid
collision.

## Linear

JAC-141

## Test plan

- `grep` for sibling names (`nix-*`, `claude-code-*`, `ai-workflows`, `cc-edge`,
  `nix-devenv`, `nix-claude`, `dryvist/`, `JacobPEvans/docs`) → **no matches**.
  Remaining external links are this repo's own + the `pre-commit` badge; exactly
  two `docs.jacobpevans.com` links (boundaries pointer + footer hub). Zero
  mermaid blocks.
- `markdownlint-cli2 README.md` → **0 errors**.
- README validator hook against the new `README.md` → **exit 0** (only a
  non-blocking "missing optional section: API" warning, expected — no API here).