### PR TITLE
fix: point callers at renamed cc- reusable workflows

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -22,7 +22,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-ci-fix.yml@main
     with:
       repo_context: "AI assistant instruction files and CLAUDE.md patterns for multi-model orchestration (Claude, Gemini, Copilot)"
       ci_structure: "ci-gate.yml (alls-green gate aggregating yaml-lint, markdownlint, spellcheck, cclint, token-limits, validate-instructions checks)"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   simplify:
-    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -47,7 +47,7 @@ jobs:
   resolve-issue:
     if: false
     needs: [run-triage]
-    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "AI assistant instruction files and CLAUDE.md patterns for multi-model orchestration"

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   next-steps:
-    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-next-steps.yml@main
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -39,7 +39,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-post-merge-docs-review.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
## Problem
Six callers referenced `dryvist/ai-workflows/.github/workflows/<name>.yml@main`
for reusables that were renamed with a `cc-` prefix. The old names no longer
exist, so every run failed at **startup** (0 jobs), driving this repo's ~50%
workflow failure rate.

## Fix
Repoint the `uses:` refs to the current names: `cc-ci-fix`,
`cc-code-simplifier`, `cc-issue-resolver`, `cc-next-steps`,
`cc-post-merge-docs-review`, `cc-post-merge-tests`. `issue-triage` (never
renamed) is left untouched. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)