### PR TITLE
docs(rules): add shell-conventions and public-disclosure rules

### DIFF
--- a/agentsmd/rules/public-disclosure.md
+++ b/agentsmd/rules/public-disclosure.md
@@ -1,0 +1,43 @@
+---
+name: public-disclosure
+description: Public/committed artifacts (code, docs, commits, PR and issue titles/bodies) disclose the minimum — state, never rationale; categories, never real-value mappings.
+---
+
+# Public Disclosure
+
+Everything in a public, git-committed artifact is published forever —
+search-indexed, archived, cross-referenced. This applies equally to file
+content, commit messages, and PR/issue titles and bodies; a PR description
+on a public repo is committed text, not a private note to the reviewer.
+
+## State what, never why or unpublished specifics
+
+Committed text describes what the code currently does. It does not restate
+the roadmap, the operational rationale, or specific hardware/vendor names for
+a swappable backend. Use capability-neutral names for infrastructure that
+might change (e.g. a role name, not a machine's make/model) and reach it by a
+stable identifier so the concrete backend behind it can change without a
+rename. A tool evaluation the user explicitly asked for is fine — keep it
+factual, about the tool, not the surrounding infrastructure.
+
+## Minimum topology disclosure
+
+Never name or characterize a private/internal system in a public artifact —
+not even generically ("the internal data repo", "our backend service").
+Existence and topology are sensitive at the same tier as literal secrets:
+naming what exists and how data flows between systems maps the attack/recon
+surface even when no credential leaks. Environment-specific identity (repo
+names, hosts, destinations) belongs behind a variable sourced from the
+runtime secret store; the committed reference is only the variable name.
+Avoid naming an individual lower-trust or self-hosted software component when
+a whole-system description of the improvement suffices.
+
+## Describe scrubs in categories, not mappings
+
+When a PR or commit describes a sanitization/scrub sweep, describe the
+**category** of value removed ("real internal hostnames → placeholder
+values"), never the **real-value → placeholder mapping** ("`prod-db-3` →
+`db-example`"). Spelling out the mapping in the PR body re-leaks exactly what
+the diff was scrubbing. The same applies to verification language — "a scan
+confirms zero real values remain" is fine; pasting the actual grep pattern
+used to find them is not, since the pattern itself can encode the real value.

--- a/agentsmd/rules/shell-conventions.md
+++ b/agentsmd/rules/shell-conventions.md
@@ -1,0 +1,35 @@
+---
+name: shell-conventions
+description: Shell variable naming and bracing conventions — bare $VAR, name intermediates after source or destination only.
+---
+
+# Shell Conventions
+
+## Bracing
+
+`$VAR` is the simplest expression and is preferred. Use `${VAR}` only when
+the next character would otherwise extend the variable name (a letter,
+digit, or underscore) — e.g. `${VAR}suffix`, `${VAR}_backup`. Never brace
+reflexively: `$HOME/anything` is correct, `${HOME}/anything` is noise.
+
+## Naming intermediates
+
+When a shell variable is just a pass-through — read from one name, fed to
+another — name it after **either** the source or the destination. Never
+invent a third name.
+
+```bash
+# Bad — CF_ACCT is neither the source name nor the destination name
+CF_ACCT=$(security find-generic-password -s CF_ACCOUNT_ID -w …)
+export CLOUDFLARE_ACCOUNT_ID=$CF_ACCT
+
+# Good — destination-named, no intermediate
+export CLOUDFLARE_ACCOUNT_ID=$(security find-generic-password -s CF_ACCOUNT_ID -w …)
+
+# Also good — source-named, used directly downstream
+CF_ACCOUNT_ID=$(security find-generic-password -s CF_ACCOUNT_ID -w …)
+some-tool -var "cloudflare_account_id=$CF_ACCOUNT_ID"
+```
+
+Triple-naming forces the reader to trace three layers (source name →
+intermediate → consumer name) instead of one.

--- a/agentsmd/rules/tool-use.md
+++ b/agentsmd/rules/tool-use.md
@@ -32,6 +32,18 @@ description: Prefer native tools over Bash equivalents (Read/Edit/Write/Grep/Glo
 | State queries | `terraform output`, Ansible facts | Query script |
 | Delegate to external AI | `/delegate-to-ai` (Codex / native subagent) | Manual model routing |
 
+When a capability isn't natively provided by a standard tool, the answer is
+"use the tool as-is, or don't do it" — not "write a small script." A custom
+wrapper script is an unmaintained, untested-at-scale liability that duplicates
+or poorly reinvents what packaged tools already do. If a desired refinement
+can't be done through the tool's native config, drop that refinement rather
+than scripting around the gap.
+
+**Never pipe or dump a bare `env`** (or `printenv`), even through a filter
+like `cut -d'=' -f1`. Multi-line values (private keys, license blobs) break
+line-based parsing and can print secret contents into the transcript/log.
+Test for a specific variable's presence with `[[ -n "$VAR" ]]` instead.
+
 ## Subagent type selection
 
 | `subagent_type` | Use when |


### PR DESCRIPTION
## Summary
- New rule `shell-conventions.md`: `$VAR` over `${VAR}` bracing, and naming shell intermediates after their source or destination (never a third invented name)
- New rule `public-disclosure.md`: generalizes several session-learned disclosure norms — committed text states what not why/rationale, minimum topology disclosure (never name or characterize private systems even generically), and describing sanitization sweeps by category rather than real-value-to-placeholder mappings
- `tool-use.md`: adds a "drop the feature rather than script around a tool gap" note, and a never-bare-`env`-dump safety rule (a real incident: piping `env` through a line-based filter printed multi-line secret values into a transcript)

## Test plan
- [x] `pre-commit run` locally: trailing-whitespace, end-of-file-fixer, markdownlint-cli2, check-markdown-links all pass
- [x] Sensitive-scrub grep on the diff (node names, internal IPs/domain, untrusted app names) — clean
- [ ] CI green

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K