### PR TITLE
chore(renovate): thin wrapper; migrate fileMatch to managerFilePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
     "local>dryvist/.github"
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^AGENTS\\.md$"],
+      "managerFilePatterns": ["/^AGENTS\\.md$/"],
       "matchStrings": ["blob/(?<currentDigest>[a-f0-9]{40})/CLAUDE\\.md"],
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/forrestchang/andrej-karpathy-skills",


### PR DESCRIPTION
chore(renovate): thin wrapper; migrate fileMatch to managerFilePatterns

Drop the redundant config:recommended (default.json already provides it) and migrate the deprecated customManager `fileMatch` to `managerFilePatterns`. Keeps the karpathy-skills CLAUDE.md digest custom manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5heppQHhv8xE1XWeeFVA