### PR TITLE
docs(deps): publisher-agnostic minor/patch auto-merge model

### DIFF
--- a/agentsmd/rules/dependency-automation.md
+++ b/agentsmd/rules/dependency-automation.md
@@ -1,3 +1,9 @@
+---
+name: dependency-automation
+description: Org dependency-freshness policy — trust tiers, auto-merge rules, and where the canonical config lives
+paths: ["**/renovate.json*", "**/renovate-presets.json", "**/renovate-grouping.json", "**/.renovaterc*"]
+---
+
 # Dependency automation (trust tiers)
 
 Every dryvist/JacobPEvans repo inherits ONE Renovate policy from `dryvist/.github`

--- a/agentsmd/rules/dependency-automation.md
+++ b/agentsmd/rules/dependency-automation.md
@@ -1,9 +1,3 @@
----
-name: dependency-automation
-description: Org dependency-freshness policy — trust tiers, auto-merge rules, and where the canonical config lives
-paths: ["**/renovate.json*", "**/renovate-presets.json", "**/renovate-grouping.json", "**/.renovaterc*"]
----
-
 # Dependency automation (trust tiers)
 
 Every dryvist/JacobPEvans repo inherits ONE Renovate policy from `dryvist/.github`
@@ -11,22 +5,34 @@ Every dryvist/JacobPEvans repo inherits ONE Renovate policy from `dryvist/.githu
 diverge from it per repo without a recorded reason. Canonical, fuller docs:
 <https://docs.jacobpevans.com/infrastructure/cicd/dependency-automation>.
 
-## The tiers
+## The model
 
-| Tier | Scope | Cadence | Auto-merge |
+**Minor/patch updates auto-merge publisher-agnostically** — any package, any ecosystem,
+any publisher — after a 3-day stabilization + green CI. **Trust tiers gate ONLY majors and
+PR-creation cadence, never minor/patch.**
+
+| Update | Scope | PR cadence | Auto-merge |
 | --- | --- | --- | --- |
-| First-party | `dryvist/**`, `JacobPEvans*/**` | immediate | all types incl. major |
-| Trusted | curated ~50-org allowlist | twice-weekly (Mon/Thu), 3d age | minor/patch only; **major → human review** |
-| Untrusted | everything else | weekly, 3d age | AI-gated: `dryvist/ai-workflows` auto-merges only `risk:low` |
-| Security/CVE | any vulnerability alert | immediate | auto-merge, overrides every tier |
+| Minor / patch | ANY package, ANY ecosystem | twice-weekly (Mon/Thu), 3d age | **yes** — publisher-agnostic, after green CI |
+| First-party (any type) | `dryvist/**`, `JacobPEvans*/**` | immediate | yes, incl. major |
+| Trusted-org major | curated ~50-org allowlist | twice-weekly (Mon/Thu), 3d age | no — 3-day review PR (`dep:review`) |
+| Other major | everything else | weekly, 30d age | no — 30-day hold, review |
+| Security / CVE | any vulnerability alert | immediate (0-day PR) | minor/patch: yes; **major: review** |
 
 ## Rules of thumb
 
-- **Never ship old versions** unless explicitly documented (rare) — freshness is the default.
-- **A trust-list entry auto-merges minor/patch, not majors** — a trusted publisher is not
-  proof of a compatible API. Never silently promote an org's majors to auto-merge.
-- **Prefer native Renovate capability over custom scripts/workflows** — debug the config,
-  don't reimplement it.
+- **Never ship old versions** — freshness is the default; a stale pin is drift to eliminate.
+- **Minor/patch is publisher-agnostic** — a non-major SemVer bump + green CI (the Merge Gate,
+  plus the deterministic `dependency-review` supply-chain scan on public repos) is sufficient;
+  trust is not required to auto-merge minor/patch.
+- **Majors never auto-merge except first-party** — a compatible-looking version is not a
+  compatible API. Trusted-org majors get a 3-day review PR; all others a 30-day hold.
+- **Security majors open for review** — `vulnerabilityAlerts` surfaces a 0-day PR, but a
+  security *major* is still reviewed (only non-major security auto-merges fast).
+- **Supply-chain safety = the deterministic `dependency-review` native-gate** inside the
+  (non-AI) Merge Gate; the AI dependency review (`dryvist/ai-workflows`) is **advisory only**,
+  under the separate **AI Merge Gate**. The two gates are always distinct and both required.
+- **Prefer native Renovate capability over custom scripts/workflows** — debug the config.
 - **`platformAutomerge` stays false** (GitHub's merge-queue stalls; Renovate merges via API).
 - Trusted GitHub Actions use semver tags; untrusted are SHA-pinned; `dryvist/*` self-refs ride `@main`.
 - When you touch trust tiers, auto-merge, or schedules, update `dryvist/.github` `SECURITY.md`


### PR DESCRIPTION
## Summary

- Rewrites `agentsmd/rules/dependency-automation.md` (the auto-loaded dependency-automation rule) to the new policy: minor/patch updates auto-merge publisher-agnostically for any package/ecosystem after green CI; trust tiers now gate only majors and PR-creation cadence, never minor/patch.
- Retires the old four-tier model (First-party / Trusted / Untrusted / Security) and its `risk:low` AI-gated auto-merge language in favor of a single Minor/patch row plus three major-update rows (First-party, Trusted-org, Other) and a Security row.
- Clarifies the two-gate model: the deterministic `dependency-review` scan lives in the (non-AI) Merge Gate; the AI dependency review (`dryvist/ai-workflows`) is advisory only, under a separate AI Merge Gate.

## Test plan

- [x] `grep -niE 'risk:low|AI-gated|minor/patch only|four tier' agentsmd/rules/dependency-automation.md` returns zero lines (retired phrasing confirmed gone).
- [x] Pre-push hooks (markdownlint-cli2, lychee-link-check, check-markdown-links) passed.
- [ ] Reviewer: confirm dropping this file's YAML frontmatter (`name`/`description`/`paths` matcher) is intentional — the replacement content did not include it (see PR conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5heppQHhv8xE1XWeeFVA