### PR TITLE
feat(rules): git-flow branching model + universal SHA pinning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,14 @@ See [docs.jacobpevans.com/conventions/no-scripts](https://docs.jacobpevans.com/c
 
 Run `/refresh-repo`, then start the change in a new worktree.
 
+## Git workflow
+
+Detect the remote default branch before any branch, PR, or release work. If it is `develop`, the
+repo is on git-flow — follow [git-flow](agentsmd/rules/git-flow.md) (git-flow-next): PRs target
+`develop` (squash-merge), `develop` → `main` promotes by merge commit only, every merge to `main`
+releases. If it is `main`, keep the existing trunk flow. Either way, always make **atomic
+commits** — one fix, one feature, or one coherent section of updates per commit.
+
 ## Knowledge base
 
 Documentation follows [Open Knowledge Format](agentsmd/rules/okf.md). Search relevant OKF concepts before editing;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,9 @@ Run `/refresh-repo`, then start the change in a new worktree.
 
 ## Git workflow
 
-Detect the remote default branch before any branch, PR, or release work. If it is `develop`, the
-repo is on git-flow — follow [git-flow](agentsmd/rules/git-flow.md) (git-flow-next): PRs target
-`develop` (squash-merge), `develop` → `main` promotes by merge commit only, every merge to `main`
-releases. If it is `main`, keep the existing trunk flow. Either way, always make **atomic
-commits** — one fix, one feature, or one coherent section of updates per commit.
+If the default branch is `develop`, follow [git-flow](agentsmd/rules/git-flow.md): PRs target
+`develop` (squash-merge), `develop` → `main` by merge commit only. If `main`, use trunk flow.
+Always make **atomic commits** — one fix, one feature, or one coherent section per commit.
 
 ## Knowledge base
 
@@ -47,13 +45,13 @@ These repos own the layer; know which one owns the change before editing.
 - Slash commands, skills, agents, hooks: [`JacobPEvans/claude-code-plugins`](https://github.com/JacobPEvans/claude-code-plugins)
 - Public docs site: [`JacobPEvans/docs`](https://github.com/JacobPEvans/docs)
 
-If a change in one repo affects the public picture, mirror the relevant slice into `JacobPEvans/docs` in the same session:
+If a change affects the public picture, mirror into `JacobPEvans/docs` the same session:
 
-- Plugin added, removed, or scope shifted -> update `docs/ai-development/claude-code-plugins.mdx` and `docs/docs.json`.
-- New user-facing rule under `agentsmd/rules/` -> mention it in `docs/ai-development/ai-assistant-instructions.mdx`.
-- Diagram edits -> keep inline mermaid and any `docs/assets/*.mmd` sources in lockstep.
-- One PR per repo; cross-link via `Refs: JacobPEvans/<repo>#N` in the PR body.
-- Per-repo docs stay local. Private or user-only content never goes in `JacobPEvans/docs`.
+- Plugin changes → `docs/ai-development/claude-code-plugins.mdx` + `docs/docs.json`.
+- New `agentsmd/rules/` rule → `docs/ai-development/ai-assistant-instructions.mdx`.
+- Diagram edits → sync inline mermaid and `docs/assets/*.mmd`.
+- One PR per repo; cross-link via `Refs: JacobPEvans/<repo>#N`.
+- Per-repo docs stay local; no private content in `JacobPEvans/docs`.
 
 Docs are descriptive; directives stay in `AGENTS.md`.
 
@@ -77,8 +75,6 @@ Subagents must return outcome, evidence, inspected or changed paths, risks, and 
 
 ## Model Selection
 
-Never hard-code model IDs or maintain a static task-to-model table — availability and names drift.
-Discover live: prefer `$AI_MODEL_LOCAL` for local general-purpose work, but verify it against live
-model discovery before use; otherwise list current models and pick the smallest capable option for
-the task. Escalate to cloud only when local models lack the context, tool support, or quality bar
-the task needs.
+Never hard-code model IDs — availability drifts. Prefer `$AI_MODEL_LOCAL` for local work (verify
+against live discovery); otherwise pick the smallest capable model. Escalate to cloud only when
+local models lack the context, tool support, or quality the task needs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@
 - Define verifiable success criteria, use the narrowest proof, and report exactly what passed or failed.
 
 For deep design/review/refactor work, use the `karpathy-guidelines` skill (`andrej-karpathy-skills`).
-Plugins, commands, skills, agents, hooks: [JacobPEvans/claude-code-plugins](https://github.com/JacobPEvans/claude-code-plugins).
 
 ## No Scripts
 

--- a/agentsmd/rules/dependency-automation.md
+++ b/agentsmd/rules/dependency-automation.md
@@ -40,6 +40,16 @@ PR-creation cadence, never minor/patch.**
   under the separate **AI Merge Gate**. The two gates are always distinct and both required.
 - **Prefer native Renovate capability over custom scripts/workflows** — debug the config.
 - **`platformAutomerge` stays false** (GitHub's merge-queue stalls; Renovate merges via API).
-- Trusted GitHub Actions use semver tags; untrusted are SHA-pinned; `dryvist/*` self-refs ride `@main`.
+- **Pin all third-party GitHub Actions (and other pinnable third-party refs) to a full commit
+  SHA** — Renovate bumps SHAs by default, so tags add risk without saving work. Every SHA pin
+  carries: (1) the exact released version tag as a trailing comment
+  (`uses: actions/checkout@<sha> # v4.2.2`) — always; if the project publishes no immutable
+  version tag, do not invent one — pick an action that has release tags, or record an explicit
+  exception; (2) an explicit Renovate tag when Renovate cannot infer the pin from context
+  (non-`uses:` pins) — e.g. `# renovate: datasource=github-tags depName=owner/repo
+  versioning=semver`. First-party `dryvist/*` self-refs are the exception and ride `@main`.
+  Older guidance allowing semver tags for "trusted" actions is retired — delete it on sight.
+- **Renovate PRs target the repo's default branch.** On git-flow repos that is `develop`
+  (see the `git-flow` rule); never add a repo-level `baseBranches` forcing `main`.
 - When you touch trust tiers, auto-merge, or schedules, update `dryvist/.github` `SECURITY.md`
   AND the canonical docs page in the same change — they must not drift.

--- a/agentsmd/rules/git-flow.md
+++ b/agentsmd/rules/git-flow.md
@@ -1,0 +1,79 @@
+---
+name: git-flow
+description: Branching and merge model — develop is the default integration branch, main is production; squash into develop, merge commits only into main; atomic commits; git-flow-next drives branch lifecycle
+---
+
+# Git flow
+
+Repos use the git-flow model as implemented by
+[git-flow-next](https://github.com/gittower/git-flow-next). The `git flow`
+CLI is installed and configured globally (nix-managed `gitflow.*` git config).
+
+## Detect adoption first
+
+Before any branch, PR, or release work, detect the repo's remote default
+branch (`gh repo view --json defaultBranchRef` or `git remote show origin`).
+
+- Default branch `develop` → the repo is on git-flow; follow this file.
+- Default branch `main` → trunk flow; keep the existing squash-to-main
+  process and do **not** create a `develop` branch yourself.
+- Never infer adoption from the current local branch name.
+
+## The model
+
+| Branch | Role | Gets changes by |
+| --- | --- | --- |
+| `main` | Production. Protected; no direct pushes. | **Merge commits only** — squash and rebase into `main` are banned, with no exceptions |
+| `develop` | Default integration branch. Protected but direct pushes allowed. | Squash-merged PRs (the default); merge commits where noted below |
+| `feature/*` | One change's work | Branched from fresh `develop` |
+| `release/*` | Optional final stabilization | Branched from `develop`; merge-committed to `main`; back-merged to `develop` |
+| `hotfix/*` | Urgent production fix | Branched from `main`; PR to `main`, merge commit; back-merged to `develop` |
+
+Every merge into `main` produces a release: release-please watches `main`,
+opens the release PR against `main`, and tags on merge. The release PR is
+merge-committed like every other PR into `main` — it is not a squash
+exception. Never merge to `main` without intending a release.
+
+Normal promotion is a merge-commit PR from `develop` to `main`. Use
+`release/*` only when final stabilization needs its own branch; then
+merge-commit it to `main` and back-merge to `develop` before more feature
+work lands.
+
+## Working a change
+
+1. Create or switch to a fresh worktree based on `origin/develop`.
+2. Start the feature branch there: `git flow feature start <name>`. When a
+   GitHub issue exists, include its number: `feature/123-fix-inventory-loader`.
+   Never invent an issue number; for issue-less maintenance use a short
+   descriptive slug.
+3. Commit **atomically**: one fix, one feature, or one coherent section of
+   updates per commit — never a grab-bag. Follow Conventional Commits.
+   Reference the issue (`#123`) in the commit or PR; use closing keywords
+   (`fixes #123`) when the change closes it.
+4. Open the PR against `develop`. **Squash-merge ordinary feature PRs.** Use a
+   merge commit into `develop` only when preserving multiple atomic commits
+   matters: stacked work, coordinated multi-commit changes, and release or
+   hotfix back-merges.
+5. Hotfix exception to PR targeting: `hotfix/*` branches from `main` and its
+   PR targets `main` (merge commit, never squash); immediately back-merge
+   `main` into `develop` afterward.
+6. Small direct commits to `develop` are permitted, but prefer a PR for
+   anything reviewable.
+
+## CI and automation on git-flow repos
+
+- Required CI runs on `pull_request` targeting `develop` (and `main` for
+  promotion PRs) and on `push` to `develop`. Release, tag, and production
+  deploy workflows stay on `main`.
+- Renovate dependency PRs target `develop` (the default branch). Do not add a
+  repo-level `baseBranches` forcing `main`.
+
+## git-flow-next usage
+
+- `git flow feature start <name>` / `git flow release start <version>` /
+  `git flow hotfix start <name>` create correctly-based branches.
+- `git flow finish` from any topic branch detects the branch type. Prefer
+  finishing via the PR flow above; use `finish` only where a PR is overkill
+  (e.g. local-only cleanup) and the branch target allows direct pushes.
+- Config keys live in git config (`gitflow.branch.*`); do not override them
+  per-repo without a recorded reason.

--- a/agentsmd/rules/git-flow.md
+++ b/agentsmd/rules/git-flow.md
@@ -12,7 +12,8 @@ CLI is installed and configured globally (nix-managed `gitflow.*` git config).
 ## Detect adoption first
 
 Before any branch, PR, or release work, detect the repo's remote default
-branch (`gh repo view --json defaultBranchRef` or `git remote show origin`).
+branch (`gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`
+or `git remote show origin`).
 
 - Default branch `develop` → the repo is on git-flow; follow this file.
 - Default branch `main` → trunk flow; keep the existing squash-to-main
@@ -42,10 +43,11 @@ work lands.
 ## Working a change
 
 1. Create or switch to a fresh worktree based on `origin/develop`.
-2. Start the feature branch there: `git flow feature start <name>`. When a
-   GitHub issue exists, include its number: `feature/123-fix-inventory-loader`.
-   Never invent an issue number; for issue-less maintenance use a short
-   descriptive slug.
+2. Start the feature branch there: `git flow feature start <name>` — pass the
+   name WITHOUT the `feature/` prefix (the tool prepends it; passing it twice
+   yields `feature/feature/…`). When a GitHub issue exists, include its number
+   in the name: `git flow feature start 123-fix-inventory-loader`. Never invent
+   an issue number; for issue-less maintenance use a short descriptive slug.
 3. Commit **atomically**: one fix, one feature, or one coherent section of
    updates per commit — never a grab-bag. Follow Conventional Commits.
    Reference the issue (`#123`) in the commit or PR; use closing keywords
@@ -54,9 +56,9 @@ work lands.
    merge commit into `develop` only when preserving multiple atomic commits
    matters: stacked work, coordinated multi-commit changes, and release or
    hotfix back-merges.
-5. Hotfix exception to PR targeting: `hotfix/*` branches from `main` and its
-   PR targets `main` (merge commit, never squash); immediately back-merge
-   `main` into `develop` afterward.
+5. Hotfix exception to PR targeting: a `hotfix/*` branch starts from `main`
+   and its PR targets `main` (merge commit, never squash); immediately
+   back-merge `main` into `develop` afterward.
 6. Small direct commits to `develop` are permitted, but prefer a PR for
    anything reviewable.
 


### PR DESCRIPTION
## What

Two convention changes, both auto-loaded org-wide via nix-ai:

1. **New `agentsmd/rules/git-flow.md`** — the git-flow-next branching model for repos whose default branch is `develop`: detection gate first (trunk repos keep the existing flow during the pilot), squash-merge PRs into `develop`, **merge-commit-only** promotion into `main` (release-please's release PR included — no squash exception), hotfix and release-branch paths, atomic-commit mandate, issue-numbered feature branches, and CI/Renovate targeting rules. `AGENTS.md` gains a matching **Git workflow** section.
2. **SHA-pinning policy** (`agentsmd/rules/dependency-automation.md`) — retires the trusted-actions-may-use-semver-tags allowance. All third-party actions pin to a full commit SHA, always with the released version tag as a trailing comment, plus an explicit `# renovate: datasource=…` tag when Renovate cannot infer the pin. First-party `dryvist/*` refs keep riding `@main`.

## Why

dryvist repos are migrating to git-flow (pilot: terraform-proxmox, ansible-proxmox-apps, nix-darwin, nix-ai, ai-assistant-instructions). Agents need the flow stated once, centrally, before the first repo flips. Renovate now bumps SHAs by default, so tag pinning adds risk without saving work.

## Notes

- Adversarial review by Codex applied: release-PR merge-method conflict, hotfix path, mixed-pilot detection gate, squash-vs-merge criteria for `develop`, no-version-tag fallback, exact renovate-tag syntax.
- Docs-site mirror (`docs/ai-development/ai-assistant-instructions.mdx` + conventions pages) follows in the dryvist/docs PR wave for the same migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9EGoFt6YZvquAVYFZURtQ