### PR TITLE
ci: widen push-to-main lint/gate wrappers to include develop

### DIFF
--- a/.github/workflows/cclint.yml
+++ b/.github/workflows/cclint.yml
@@ -1,11 +1,11 @@
-# Claude Code Lint - Push to main wrapper
+# Claude Code Lint - Push to main/develop wrapper
 # PRs are validated via ci-gate.yml
 
 name: Claude Code Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '.claude/**'
       - 'agentsmd/**'

--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["CI Gate"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
 ---
 

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI Gate"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   actions: read

--- a/.github/workflows/file-size.yml
+++ b/.github/workflows/file-size.yml
@@ -1,11 +1,11 @@
-# File Size Check - Push to main wrapper
+# File Size Check - Push to main/develop wrapper
 # PRs are validated via ci-gate.yml
 
 name: File Size
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '**/*.md'
       - '**/*.nix'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -2,7 +2,7 @@ name: Link Check
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,11 +1,11 @@
-# Markdown Lint - Push to main wrapper
+# Markdown Lint - Push to main/develop wrapper
 # PRs are validated via ci-gate.yml
 
 name: Markdown Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '**/*.md'
       - '.markdownlint-cli2.jsonc'

--- a/.github/workflows/token-limits.yml
+++ b/.github/workflows/token-limits.yml
@@ -1,11 +1,11 @@
-# Token Limit Check - Push to main wrapper
+# Token Limit Check - Push to main/develop wrapper
 # PRs are validated via ci-gate.yml
 
 name: Token Limit Check
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '.claude/**'
       - 'agentsmd/**'

--- a/.github/workflows/validate-cclint-schema.yml
+++ b/.github/workflows/validate-cclint-schema.yml
@@ -1,11 +1,11 @@
-# Schema Validation - Push to main wrapper
+# Schema Validation - Push to main/develop wrapper
 # PRs are validated via ci-gate.yml
 
 name: Schema Validation
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '.cclintrc.jsonc'
   workflow_dispatch:

--- a/.github/workflows/validate-instructions.yml
+++ b/.github/workflows/validate-instructions.yml
@@ -1,11 +1,11 @@
-# Instruction Validation - Push to main wrapper
+# Instruction Validation - Push to main/develop wrapper
 # PRs are validated via ci-gate.yml
 
 name: Instruction Validation
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'agentsmd/**'
 

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,11 +1,11 @@
-# YAML Lint - Push to main wrapper
+# YAML Lint - Push to main/develop wrapper
 # PRs are validated via ci-gate.yml
 
 name: YAML Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '**/*.yml'
       - '**/*.yaml'


### PR DESCRIPTION
## What

Widens `push`/`workflow_run` triggers that were hardcoded to `main` so they also cover `develop`, ahead of the git-flow-next pilot flip.

**Eight post-merge lint/gate wrapper workflows** — `push: branches: [main]` -> `[main, develop]`:

- `cclint.yml`
- `file-size.yml`
- `link-check.yml`
- `markdownlint.yml`
- `token-limits.yml`
- `validate-cclint-schema.yml`
- `validate-instructions.yml`
- `yaml-lint.yml`

**Two CI-Gate-completion consumers** — `workflow_run: branches: [main]` -> `[main, develop]`:

- `ci-fail-issue.yml` (opens an issue when CI Gate fails)
- `ci-doctor.md` (gh-aw agentic CI failure triage) — see lock-file note below

## Why

Ahead of the git-flow-next pilot flip, `develop` becomes a long-lived branch that accepts direct pushes. These wrapper workflows exist to catch anything that slips past PR-time checks (`ci-gate.yml`) on a push to the trunk, and the CI-Gate-completion consumers exist to auto-triage failures — both safety nets need to cover `develop`, not just `main`.

## Scope notes

- `release-please.yml` and `dispatch-flake-consumers.yml` intentionally stay `main`-only — release cadence and downstream flake-consumer dispatch are tied to the released state, not `develop`.
- No `pull_request` trigger in this repo restricts `branches`, so PR-time checks (`ci-gate.yml`, `ai-merge-gate.yml`, etc.) already run against develop-targeted PRs unchanged.
- `release-please-config.json` / `.release-please-manifest.json` / `release-please.yml` were verified present and already following the org-standard pattern — no gap.
- `ci-fix.yml` and `copilot-ci-fix.yml` needed no change: `ci-fix.yml` already runs for any branch other than `main` via a job-level condition (`head_branch != 'main'`), and `copilot-ci-fix.yml` has no branch filter at the trigger level at all.
- Four gh-aw `.md`/`.lock.yml` pairs were checked (`ci-doctor`, `daily-malicious-code-scan`, `link-checker`, `sub-issue-closer`); only `ci-doctor` used a `pull_request`/`push`-adjacent (`workflow_run`) branch filter needing a change — the other three are schedule/workflow_dispatch only.

## Known gap — `ci-doctor.lock.yml` not regenerated

`ci-doctor.md` (the gh-aw source) is updated, but `ci-doctor.lock.yml` is **intentionally left as-is** in this PR. The only `gh aw` CLI available in this environment is a "dev" build newer than the repo's pinned `v0.68.3`; running `gh aw compile ci-doctor` with it silently upgraded the entire toolchain (schema version, action SHAs, container images) as a side effect of what should be a one-line trigger change — well out of scope here. **Follow-up needed:** regenerate `ci-doctor.lock.yml` with the pinned `v0.68.3` toolchain so only the `branches` list changes.

## Open PRs targeting main (not retargeted here, per instructions — retarget happens at flip time)

- #724 `feat(rules): git-flow branching model + universal SHA pinning` (author: JacobPEvans-personal)
- #723 `chore(deps): update actions/checkout action to v7` (author: renovate) — will auto-retarget after the default-branch change per Renovate's own behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01D9EGoFt6YZvquAVYFZURtQ