### PR TITLE
docs: standardize worktree placement at ./.worktrees inside the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ result
 *credentials*
 *.jsonl
 *.local.*
+
+# In-repo worktrees (see agentsmd/rules/git-flow.md "Working a change")
+.worktrees/

--- a/agentsmd/rules/git-flow.md
+++ b/agentsmd/rules/git-flow.md
@@ -42,7 +42,11 @@ work lands.
 
 ## Working a change
 
-1. Create or switch to a fresh worktree based on `origin/develop`.
+1. Create or switch to a fresh worktree based on `origin/develop`. Place it at
+   `./.worktrees/<name>/` inside the repo (create `.worktrees/` if absent; keep
+   it gitignored). The repo root checkout always stays on the default branch
+   (`develop`, or `main` on trunk repos) — never check a feature branch out at
+   the root.
 2. Start the feature branch there: `git flow feature start <name>` — pass the
    name WITHOUT the `feature/` prefix (the tool prepends it; passing it twice
    yields `feature/feature/…`). When a GitHub issue exists, include its number


### PR DESCRIPTION
Feature worktrees now live at `./.worktrees/<name>/` (gitignored) inside the repo, and the root checkout always stays on the default branch (`develop`, or `main` on trunk repos).

Why: the workspace reorg (2026-07-10) established dir-basename = repo-name; sibling `<repo>-worktrees`/`-wt` dirs broke that and accumulated as clutter. In-repo `.worktrees/` keeps everything under the one canonical clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NopNWJek64JUnQrD3Xhwrw