### PR TITLE
fix(rules): anchor worktree placement to repo root, not cwd

### DIFF
--- a/agentsmd/rules/git-flow.md
+++ b/agentsmd/rules/git-flow.md
@@ -43,15 +43,15 @@ work lands.
 ## Working a change
 
 1. Create or switch to a fresh worktree based on `origin/develop`. Place it at
-   the repo's **top level** as `.worktrees/<name>/` — the directory that holds
-   the repo's `.git` (a normal clone's root; for a bare-repo layout, the level
-   *beside* the primary checkout, never inside it). Anchor the path explicitly,
-   e.g. `git -C <repo-root> worktree add .worktrees/<name> …` — never a
-   cwd-relative `./.worktrees/<name>/`, which nests wrongly when run from
-   inside another worktree or a subdir checkout (create `.worktrees/` if
-   absent; keep it gitignored). The repo root checkout always stays on the
-   default branch (`develop`, or `main` on trunk repos) — never check a
-   feature branch out at the root.
+   the repo's top level as `.worktrees/<name>/` — beside the primary checkout,
+   never nested inside it. Pass `git worktree add` an **absolute** destination
+   path so the current directory cannot change where it lands, e.g.
+   `git worktree add /abs/path/to/<repo>/.worktrees/<name> origin/develop`. A
+   relative `.worktrees/<name>` resolves against your cwd — from inside the
+   `main/` checkout it nests as `main/.worktrees/<name>`, which is wrong.
+   Create `.worktrees/` if absent; keep it gitignored. The repo root checkout
+   always stays on the default branch (`develop`, or `main` on trunk repos) —
+   never check a feature branch out at the root.
 2. Start the feature branch there: `git flow feature start <name>` — pass the
    name WITHOUT the `feature/` prefix (the tool prepends it; passing it twice
    yields `feature/feature/…`). When a GitHub issue exists, include its number

--- a/agentsmd/rules/git-flow.md
+++ b/agentsmd/rules/git-flow.md
@@ -43,10 +43,15 @@ work lands.
 ## Working a change
 
 1. Create or switch to a fresh worktree based on `origin/develop`. Place it at
-   `./.worktrees/<name>/` inside the repo (create `.worktrees/` if absent; keep
-   it gitignored). The repo root checkout always stays on the default branch
-   (`develop`, or `main` on trunk repos) — never check a feature branch out at
-   the root.
+   the repo's **top level** as `.worktrees/<name>/` — the directory that holds
+   the repo's `.git` (a normal clone's root; for a bare-repo layout, the level
+   *beside* the primary checkout, never inside it). Anchor the path explicitly,
+   e.g. `git -C <repo-root> worktree add .worktrees/<name> …` — never a
+   cwd-relative `./.worktrees/<name>/`, which nests wrongly when run from
+   inside another worktree or a subdir checkout (create `.worktrees/` if
+   absent; keep it gitignored). The repo root checkout always stays on the
+   default branch (`develop`, or `main` on trunk repos) — never check a
+   feature branch out at the root.
 2. Start the feature branch there: `git flow feature start <name>` — pass the
    name WITHOUT the `feature/` prefix (the tool prepends it; passing it twice
    yields `feature/feature/…`). When a GitHub issue exists, include its number


### PR DESCRIPTION
## Summary
git-flow.md's "Working a change" step told sessions to place worktrees at a
cwd-relative `./.worktrees/<name>/`. In bare-layout repos whose primary
checkout is a `main/` subdir, running from `main/` nested new worktrees under
`main/.worktrees/` instead of the repo root. This anchors the instruction to
an absolute destination path so the session's cwd can't change where the
worktree lands.

## Changes
- `agentsmd/rules/git-flow.md` — rewrite step 1: place `.worktrees/<name>/` at
  the repo top level beside the primary checkout; pass `git worktree add` an
  **absolute** destination path; call out that a relative `.worktrees/<name>`
  nests under `main/` when run from the checkout.

## Test Plan
- [x] `pre-commit run` (markdownlint, link check, EOF/whitespace) passes
- [x] All CI checks green; CodeQL 0; review thread resolved
- [x] Dogfooded: this PR's own worktree lives at the repo root
  (`.worktrees/fix-worktree-placement/`), not nested under `main/`

## Notes
- Review raised mirroring rule changes to the docs repo's `.mdx`; deferred as
  follow-up — this is a wording tweak to an existing rule, not a new rule.