### PR TITLE
chore: remove shellcheck references

### DIFF
--- a/TOOL_VERSIONS.md
+++ b/TOOL_VERSIONS.md
@@ -61,15 +61,6 @@ For markdown linting validation.
 - **Alternative**: `npm install -g markdownlint-cli2`
 - **Verify**: `markdownlint-cli2 --version`
 
-### shellcheck
-
-For shell script validation.
-
-- **Minimum version**: 0.8.0
-- **Nix package**: [`shellcheck`](https://search.nixos.org/packages?query=shellcheck)
-- **Alternative**: `brew install shellcheck`
-- **Verify**: `shellcheck --version`
-
 ### yamllint
 
 For YAML validation.

--- a/agentsmd/permissions/allow/local-overrides.json
+++ b/agentsmd/permissions/allow/local-overrides.json
@@ -137,8 +137,7 @@
     "uv venv *",
     "wdutil info *",
     "wg *",
-    "wg-quick *",
-    "which shellcheck *"
+    "wg-quick *"
   ],
   "_domains": [
     "claudecodecommands.directory",
@@ -385,7 +384,6 @@
     "gh issue list": "git/public/.github-jacobpevans/.claude/settings.local.json",
     "/Users/jevans/git/.github/fix/simplify-renovate-regex/**": "git/public/.github-jacobpevans/main/.claude/settings.local.json",
     "./scripts/check-no-runner-git-commit.sh ~/git/JacobPEvans/main/.github/workflows/snake.yml ~/git/JacobPEvans/main/.github/workflows/3d-contrib.yml": "git/.claude/settings.local.json",
-    "which shellcheck *": "git/dryvist-private/nix-screenpipe/main/.claude/settings.local.json",
     "/Users/jevans/git/public/claude-code-plugins/feat/wrap-up-resume-mode/scripts/**": "git/public/claude-code-plugins/main/.claude/settings.local.json",
     "mkdir -p /Users/jevans/git/claude-code-plugins/feat/add-categories-metadata/.claude-plugin/categories": "git/public/claude-code-plugins/main/.claude/settings.local.json",
     "/Users/jevans/git/dryvist-private/nix-screenpipe/chore/metrics-v2.4.234/**": "git/dryvist-private/nix-screenpipe/main/.claude/settings.local.json",


### PR DESCRIPTION
Per maintainer decision, shellcheck is no longer used anywhere.

- Remove the `### shellcheck` install section from `TOOL_VERSIONS.md`.
- Remove the two `which shellcheck *` entries from the auto-collected
  permission allowlist (`local-overrides.json`).

JSON re-validated with `jq`. Generated GHAW `*.lock.yml` and CHANGELOG history
are not rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)