### PR TITLE
docs: adopt Terrakube infrastructure guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The documentation covers:
 
 - **Code Standards** - Consistency across languages
 - **Documentation Standards** - AI-friendly markdown
-- **Infrastructure Standards** - Terraform/Terragrunt patterns
+- **Infrastructure Standards** - OpenTofu, Terrakube, and OpenBao patterns
 - **DRY Principle** - Why everything symlinks to one place
 - **Memory Bank** - Maintaining AI context across sessions
 - **Remote Commit Workflow** - Making commits via GitHub API without local clone

--- a/docs/codex-quick-start.md
+++ b/docs/codex-quick-start.md
@@ -54,7 +54,7 @@ Example prompt patterns:
 - `Analyze this repo, summarize the workflow contracts, then tell me the safest first edit.`
 - `Implement the smallest change in this worktree, then run the repo's documented validation.`
 - `Review this diff for bugs, regressions, and missing tests.`
-- `For this Terraform repo, use the documented aws-vault + doppler + terragrunt wrapper exactly.`
+- `For this OpenTofu repo, use its documented Terrakube workspace and native OpenBao credential flow exactly.`
 - `If repo docs conflict with your assumptions, trust the repo docs and call out the mismatch.`
 
 ## What To Port Next


### PR DESCRIPTION
## Summary\n\nPart of the coordinated dryvist fleet migration to native OpenTofu execution in the homelab Terrakube control plane, with Terrakube workspace locking and short-lived OpenBao workload identity.\n\n## Safety\n\n- Draft only; do not merge independently.\n- No production apply or state migration was performed.\n- State migration requires an approved window, refresh-only proof, and rollback snapshot.\n- General WAN egress remains blocked as a release gate until the homelab artifact mirror is seeded and validated.