### PR TITLE
feat(rules): session-coordination protocol rule (L0/L1 of #749)

### DIFF
--- a/agentsmd/rules/on-demand/git-flow.md
+++ b/agentsmd/rules/on-demand/git-flow.md
@@ -57,9 +57,14 @@ work lands.
    never check a feature branch out at the root.
 2. Start the feature branch there: `git flow feature start <name>` — pass the
    name WITHOUT the `feature/` prefix (the tool prepends it; passing it twice
-   yields `feature/feature/…`). When a GitHub issue exists, include its number
-   in the name: `git flow feature start 123-fix-inventory-loader`. Never invent
-   an issue number; for issue-less maintenance use a short descriptive slug.
+   yields `feature/feature/…`). Branch names carry the session id (see the
+   session-coordination rule): `<issue>-<sid8>-<slug>`, e.g.
+   `git flow feature start 123-03a3a401-fix-inventory-loader`, and the
+   worktree dir matches the name. This makes branch and worktree names unique
+   per session — two sessions can never collide on either. Never invent an
+   issue number; for issue-less maintenance drop that segment
+   (`<sid8>-<slug>`). **One session, one branch**: never commit to or push
+   another session's branch.
 3. Commit **atomically**: one fix, one feature, or one coherent section of
    updates per commit — never a grab-bag. Follow Conventional Commits.
    Reference the issue (`#123`) in the commit or PR; use closing keywords
@@ -73,6 +78,15 @@ work lands.
    back-merge `main` into `develop` afterward.
 6. Small direct commits to `develop` are permitted, but prefer a PR for
    anything reviewable.
+
+## Bot-owned files in rebases and merges
+
+release-please owns `CHANGELOG.md` and its manifest files. When a rebase or
+merge onto `develop` conflicts on a bot-owned file, always take the incoming
+`develop` side (`git checkout --theirs <file>` during rebase) — never
+hand-merge bot content, and never add a `merge=ours` gitattribute for it
+(that silently discards release history). Squash your own commits into one
+before rebasing across bot commits to cut the conflict surface.
 
 ## CI and automation on git-flow repos
 

--- a/agentsmd/rules/on-demand/session-coordination.md
+++ b/agentsmd/rules/on-demand/session-coordination.md
@@ -1,0 +1,139 @@
+---
+name: session-coordination
+description: Runtime-neutral protocol for concurrent agent sessions — session identity, claim-before-work, per-resource expiring locks with fencing, and hand-off; enforcement lives server-side, this file is the shared contract
+---
+
+# Session Coordination
+
+Many agent sessions run at once, across runtimes. This rule is the one
+contract they all follow so they stop colliding. It uses only systems that
+already exist (GitHub, the secrets engine's KV store, the IaC platform's
+workspace locks). There is no coordination daemon and no global mutex — a
+global cross-system lease was tried once and retired for coupling independent
+systems; it stays retired. Locks are per-resource, always expire, and can
+always be overridden after expiry. Tracking:
+dryvist/ai-assistant-instructions#749.
+
+Enforcement lives **server-side** (branch rulesets, merge queues, CAS writes,
+workspace-lock 409s). This file makes every runtime a well-behaved client;
+it is not itself the safety mechanism.
+
+## Session identity
+
+Every session mints one identity at start and uses it everywhere:
+
+```text
+<runtime>-<host>-<8hex>        # example: claude-mbp-03a3a401
+```
+
+- `runtime`: `claude`, `codex`, `agy`, `hermes`, or the CLI's short name.
+- `host`: short hostname.
+- `8hex`: first 8 hex chars of the session/conversation id; if the runtime
+  exposes none, generate once: `openssl rand -hex 4`.
+
+Stamp it into branch names, worktree names, lock records, workspace lock
+descriptions, and PR bodies. It is how another session (or the user) finds
+out who holds what.
+
+## Claim before work (GitHub-native)
+
+Before starting on an issue, bug, or feature:
+
+1. **Look for an existing claim.** An open draft PR or an assigned issue that
+   covers the same work is a claim:
+
+   ```bash
+   gh pr list --state open --json number,isDraft,headRefName,title,body
+   gh issue view <n> --json assignees
+   ```
+
+   If claimed, do not duplicate — pick other work, or offer consolidation
+   (comment on the PR/issue with your session id and intent; the earliest
+   claim wins unless its session is dead).
+
+2. **Claim.** Self-assign the issue (when one exists) and open a **draft PR
+   at first commit**, not at completion. The draft PR is the presence signal
+   every runtime can read. Put the session id in the PR body.
+
+3. **Release.** Marking the PR ready / merging / closing releases the claim.
+   An abandoned claim is steal-able: a draft PR with no new commits and no
+   author activity for 24h, or whose session is known dead, may be taken over
+   — comment first, then continue on a **new branch** (never push to another
+   session's branch).
+
+## One session, one branch
+
+Branches follow `feature/<issue>-<sid8>-<slug>` (see the git-flow rule).
+Never check out, commit to, or push another session's branch. This makes
+git-level push races structurally impossible; there are no git locks to take.
+
+## Per-resource locks (deploy-adjacent resources only)
+
+Shared mutable resources that git cannot serialize — an inventory group
+converge, a shared publish target — take a KV lock in the secrets engine.
+Never lock what a native arbiter already owns (the IaC platform queues its
+own workspace runs; GitHub queues its own merges).
+
+Lock record, one KV entry per resource at `secret/locks/<domain>/<resource>`:
+
+```json
+{
+  "holder": "claude-mbp-03a3a401",
+  "acquired_at": "2026-07-17T06:40:00Z",
+  "expires_at": "2026-07-17T07:10:00Z",
+  "fence": 7,
+  "note": "converging media inventory group"
+}
+```
+
+- **Acquire** = create-if-absent: `bao kv put -cas=0 secret/locks/<d>/<r> ...`.
+  A CAS failure means someone holds it — read the record, report holder and
+  expiry, back off with jitter or pick other work. Never busy-wait.
+- **Renew** (holder only) = `-cas=<current-version>` with a later
+  `expires_at`. Renew before expiry for long work; a session that cannot
+  renew has lost the lock and MUST stop the protected work.
+- **Release** (holder only) = `-cas=<current-version>` writing
+  `{"released": true}` (or delete the version). Always release on clean exit.
+- **Steal** — only when `expires_at` is in the past (allow ≥60s clock-skew
+  margin): re-read, then write with `-cas=<version-you-read>` and
+  `fence: <old fence + 1>`. **Never delete metadata to steal** — a metadata
+  delete can destroy a lock someone else just acquired. A failed CAS on steal
+  means you lost the race; re-read and re-evaluate.
+- **Fencing.** Carry the `fence` value into the protected operation's logs
+  and artifacts, so work from a stale holder is detectable after a steal.
+- **TTL sizing.** `expires_at` = now + expected work + margin; keep it short
+  (minutes, not hours) — crashed sessions are the norm, and expiry is the
+  cleanup. Sessions die without releasing; that must never require a human.
+
+## Workspace locks (IaC platform)
+
+The lock action itself is the decision — checking first and planning after is
+a race. Plan **and** apply under the lock; put the JSON lock record above in
+the lock description. Override only after `expires_at`, after re-reading to
+confirm the holder has not changed, using the platform's normal unlock — and
+announce it (see notifications). Details live in the infra skills.
+
+## Hand-off and hand-back
+
+To consolidate overlapping work onto one session:
+
+- The yielding session pushes its branch, notes state in the draft PR
+  (done / remaining / gotchas), unassigns itself, and comments
+  `handing off to <session-id>`.
+- The receiving session self-assigns, continues on its **own** branch (based
+  on the yielded branch if useful), and closes or supersedes the old draft PR.
+- Hand-back is the same protocol in reverse. The PR trail is the transfer
+  record; no side channel required.
+
+## Notifications (advisory)
+
+Publish steals, overrides, and hand-offs to the existing ntfy topic `coord`
+(`curl -d "<session-id>: stole lock <domain>/<resource> (fence n)" <ntfy>/coord`).
+Advisory only — never a gate.
+
+## Crash recovery expectations
+
+- Locks: expire on their own; the next contender steals cleanly.
+- Claims: draft PRs persist; the 24h-stale rule above unblocks them.
+- Worktrees: a dead session's worktree is reaped by the normal sweep once its
+  branch's PR is closed/merged — session-id naming ties the two together.

--- a/agentsmd/rules/soul.md
+++ b/agentsmd/rules/soul.md
@@ -74,6 +74,7 @@ are **not** auto-loaded — read the file under `agentsmd/rules/on-demand/` when
 you begin that activity:
 
 - Git branch / PR / release → `git-flow.md` (feature/* off develop, squash to develop, merge-commit only to main).
+- Starting work / claiming / locking shared resources → `session-coordination.md` (session identity, claim-before-work, expiring per-resource locks with fencing).
 - Spawning subagents → `subagent-resilience.md` (probe first, bound concurrency, solo fallback).
 - Recurring / heartbeat loop → `loop-cadence.md` (min-interval gate + durable marker).
 - Delegating, or after a denial → `delegation-trust.md` (the full no-laundering contract).


### PR DESCRIPTION
First slice of #749 (P0): the L0 runtime-neutral coordination contract plus the L1 git-flow changes.

- New `agentsmd/rules/on-demand/session-coordination.md`: session identity, claim-before-work, per-resource expiring locks (CAS acquire/renew/steal with fencing, never metadata-delete), workspace plan-under-lock, hand-off protocol, advisory notifications.
- `git-flow.md`: branch names now carry the session id (`<issue>-<sid8>-<slug>`), one-session-one-branch invariant, bot-owned-file conflict recipe (take develop's side; no merge=ours).
- `soul.md`: tier-index entry for the new rule.

Session: claude-mbp-03a3a401

🤖 Generated with [Claude Code](https://claude.com/claude-code)