### PR TITLE
fix(rules): KV-v2 lock acquire semantics for existing keys (#749)

### DIFF
--- a/agentsmd/rules/on-demand/session-coordination.md
+++ b/agentsmd/rules/on-demand/session-coordination.md
@@ -98,7 +98,9 @@ Lock record, one KV entry per resource at `secret/locks/<domain>/<resource>`:
   `expires_at`. Renew before expiry for long work; a session that cannot
   renew has lost the lock and MUST stop the protected work.
 - **Release** (holder only) = `-cas=<current-version>` writing
-  `{"released": true}` (or delete the version). Always release on clean exit.
+  `{"released": true}`. Never delete the version — a deleted version reads
+  back as 404, hiding the version number the next acquirer's CAS write
+  needs. Always release on clean exit.
 - **Steal** — only when `expires_at` is in the past (allow ≥60s clock-skew
   margin): re-read, then write with `-cas=<version-you-read>` and
   `fence: <old fence + 1>`. **Never delete metadata to steal** — a metadata

--- a/agentsmd/rules/on-demand/session-coordination.md
+++ b/agentsmd/rules/on-demand/session-coordination.md
@@ -86,9 +86,14 @@ Lock record, one KV entry per resource at `secret/locks/<domain>/<resource>`:
 }
 ```
 
-- **Acquire** = create-if-absent: `bao kv put -cas=0 secret/locks/<d>/<r> ...`.
-  A CAS failure means someone holds it — read the record, report holder and
-  expiry, back off with jitter or pick other work. Never busy-wait.
+- **Acquire.** First-ever use of a path = create-if-absent:
+  `bao kv put -cas=0 secret/locks/<d>/<r> ...`. Once a lock record exists,
+  KV-v2 metadata persists across releases, so `cas=0` fails forever after —
+  acquire a released or expired lock by reading the record, verifying it is
+  released or past `expires_at`, then writing with `-cas=<latest-version>`.
+  A CAS failure means someone holds it (or beat you to it) — read the
+  record, report holder and expiry, back off with jitter or pick other
+  work. Never busy-wait.
 - **Renew** (holder only) = `-cas=<current-version>` with a later
   `expires_at`. Renew before expiry for long work; a session that cannot
   renew has lost the lock and MUST stop the protected work.


### PR DESCRIPTION
Review on the coordination ADR (docs-starlight#193, gemini-code-assist) caught a real protocol bug: `cas=0` only succeeds when a key's metadata has never existed, so the rule's acquire step would deadlock every lock path after its first release. Re-acquire now reads the record, verifies released/expired, and writes with `cas=<latest-version>`.

Session: claude-mbp-03a3a401

🤖 Generated with [Claude Code](https://claude.com/claude-code)