### PR TITLE
docs(rules): three-step promotion contract (merge + deploy-file move + e2e) (#749)

### DIFF
--- a/agentsmd/rules/on-demand/git-flow.md
+++ b/agentsmd/rules/on-demand/git-flow.md
@@ -53,11 +53,11 @@ complete only when:
    (e.g. `dispatch-flake-consumers`), verify it fired AND the resulting
    consumer PR merged; if the consumer is itself git-flow, its own
    develop→main promotion is part of this chain.
-3. **A full e2e deployment validates `main`.** Deploy from the consumer's
-   `main` (e.g. `darwin-rebuild switch`, converge, apply) and verify the
-   promoted change actually works in production shape. A promotion nobody
-   deployed is unvalidated — sessions must not treat `main` as good until
-   this has happened.
+3. **A full e2e deployment validates the promotion.** Deploy from the
+   consumer's deploy branch (e.g. `darwin-rebuild switch`, converge, apply)
+   and verify the promoted change actually works in production shape. A
+   promotion nobody deployed is unvalidated — sessions must not treat
+   `main` as good until this has happened.
 
 Report a promotion as complete only with all three done, and say what the
 e2e deployment was and what it verified.

--- a/agentsmd/rules/on-demand/git-flow.md
+++ b/agentsmd/rules/on-demand/git-flow.md
@@ -40,6 +40,28 @@ Normal promotion is a merge-commit PR from `develop` to `main`. Use
 merge-commit it to `main` and back-merge to `develop` before more feature
 work lands.
 
+### Promotion is not done at the merge
+
+Merging the promotion PR is step one of three. A promotion to `main` is
+complete only when:
+
+1. **The merge lands** (merge commit; release-please takes over versioning).
+2. **The deployment file moves.** Any consumer that pins this repo (a flake
+   input in another repo's `flake.lock`, an inventory pin, a version file)
+   must pick up the promoted rev on the consumer's own **deploy branch** —
+   not just its default branch. Where a dispatch workflow automates the bump
+   (e.g. `dispatch-flake-consumers`), verify it fired AND the resulting
+   consumer PR merged; if the consumer is itself git-flow, its own
+   develop→main promotion is part of this chain.
+3. **A full e2e deployment validates `main`.** Deploy from the consumer's
+   `main` (e.g. `darwin-rebuild switch`, converge, apply) and verify the
+   promoted change actually works in production shape. A promotion nobody
+   deployed is unvalidated — sessions must not treat `main` as good until
+   this has happened.
+
+Report a promotion as complete only with all three done, and say what the
+e2e deployment was and what it verified.
+
 ## Working a change
 
 1. Create or switch to a fresh worktree based on `origin/develop`. Place it at

--- a/agentsmd/rules/on-demand/session-coordination.md
+++ b/agentsmd/rules/on-demand/session-coordination.md
@@ -138,6 +138,15 @@ Publish steals, overrides, and hand-offs to the existing ntfy topic `coord`
 (`curl -d "<session-id>: stole lock <domain>/<resource> (fence n)" <ntfy>/coord`).
 Advisory only — never a gate.
 
+## Promotion follow-through
+
+A develop→main promotion is a three-step contract (see the git-flow rule):
+merge, deployment-file move in every consumer (on the consumer's deploy
+branch), and a full e2e deployment that validates `main`. For coordination
+this matters twice: the promoting session owns all three steps (do not hand
+back or report done after the merge alone), and other sessions must treat a
+merged-but-undeployed `main` as unvalidated.
+
 ## Crash recovery expectations
 
 - Locks: expire on their own; the next contender steals cleanly.

--- a/agentsmd/rules/on-demand/session-coordination.md
+++ b/agentsmd/rules/on-demand/session-coordination.md
@@ -142,7 +142,8 @@ Advisory only — never a gate.
 
 A develop→main promotion is a three-step contract (see the git-flow rule):
 merge, deployment-file move in every consumer (on the consumer's deploy
-branch), and a full e2e deployment that validates `main`. For coordination
+branch), and a full e2e deployment from that deploy branch that validates
+the promotion. For coordination
 this matters twice: the promoting session owns all three steps (do not hand
 back or report done after the merge alone), and other sessions must treat a
 merged-but-undeployed `main` as unvalidated.


### PR DESCRIPTION
User-directed correction to the promotion flow: a develop→main merge alone is not a completed promotion. git-flow.md now specifies the three-step contract (merge → consumer deployment-file move on the consumer's deploy branch, incl. chained promotions for git-flow consumers → full e2e deployment validating main), and session-coordination.md binds the promoting session to own all three steps.

Session: claude-mbp-03a3a401

🤖 Generated with [Claude Code](https://claude.com/claude-code)