### PR TITLE
fix(rules): develop requires a PR; document --auto merge path (#749)

### DIFF
--- a/agentsmd/rules/on-demand/git-flow.md
+++ b/agentsmd/rules/on-demand/git-flow.md
@@ -25,7 +25,7 @@ or `git remote show origin`).
 | Branch | Role | Gets changes by |
 | --- | --- | --- |
 | `main` | Production. Protected; no direct pushes. | **Merge commits only** — squash and rebase into `main` are banned, with no exceptions |
-| `develop` | Default integration branch. Protected but direct pushes allowed. | Squash-merged PRs (the default); merge commits where noted below |
+| `develop` | Default integration branch. Protected; no direct pushes. | Squash-merged PRs (the default); merge commits where noted below |
 | `feature/*` | One change's work | Branched from fresh `develop` |
 | `release/*` | Optional final stabilization | Branched from `develop`; merge-committed to `main`; back-merged to `develop` |
 | `hotfix/*` | Urgent production fix | Branched from `main`; PR to `main`, merge commit; back-merged to `develop` |
@@ -98,8 +98,13 @@ e2e deployment was and what it verified.
 5. Hotfix exception to PR targeting: a `hotfix/*` branch starts from `main`
    and its PR targets `main` (merge commit, never squash); immediately
    back-merge `main` into `develop` afterward.
-6. Small direct commits to `develop` are permitted, but prefer a PR for
-   anything reviewable.
+6. **Every change to `develop` goes through a PR** — the org ruleset enforces
+   it, so a direct push is rejected (`GH013: Repository rule violations`).
+   Never plan a "quick direct commit" to `develop`; branch and open a PR.
+7. **Merging**: `gh pr merge <n> --squash` is rejected with "the base branch
+   policy prohibits the merge" while required checks are still settling. Use
+   `gh pr merge <n> --squash --auto` — it merges as soon as the policy is
+   satisfied. The same applies to `--merge` on promotion PRs.
 
 ## Bot-owned files in rebases and merges
 
@@ -122,8 +127,9 @@ before rebasing across bot commits to cut the conflict surface.
 
 - `git flow feature start <name>` / `git flow release start <version>` /
   `git flow hotfix start <name>` create correctly-based branches.
-- `git flow finish` from any topic branch detects the branch type. Prefer
-  finishing via the PR flow above; use `finish` only where a PR is overkill
-  (e.g. local-only cleanup) and the branch target allows direct pushes.
+- `git flow finish` from any topic branch detects the branch type, but it
+  lands work by merging and pushing the target branch directly — which both
+  `main` and `develop` reject here. Always finish through the PR flow above;
+  `finish` is only for local branch cleanup.
 - Config keys live in git config (`gitflow.branch.*`); do not override them
   per-repo without a recorded reason.


### PR DESCRIPTION
Fixes the highest-count failure class found in the coordination mining (refs #749): the git-flow rule told agents direct pushes to `develop` were allowed, but the org ruleset carries a `pull_request` rule that rejects them (`GH013`). Agents followed the doc, got rejected, and pivoted to PR flow — repeatedly, across nearly every repo.

Verified live before changing: `gh api repos/dryvist/ai-assistant-instructions/rules/branches/develop` returns a `pull_request` rule; `org_gitflow_develop` in tofu-github is its source.

- Branch table: `develop` is "Protected; no direct pushes" (matches `main`'s wording).
- Working a change step 6: every change to `develop` goes through a PR.
- New step 7: `gh pr merge --auto` is the merge path — a bare `--squash`/`--merge` is rejected with "the base branch policy prohibits the merge" while checks settle (hit twice last session).
- git-flow-next usage: `finish` pushes the target branch directly, which both protected branches reject — it is for local cleanup only.

Session: claude-mbp-03a3a401

🤖 Generated with [Claude Code](https://claude.com/claude-code)