### PR TITLE
fix(ci): accept HTTP redirects in link check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -31,6 +31,7 @@ jobs:
           args: >-
             --verbose
             --no-progress
+            --accept '200..=299,301,302,308'
             --exclude 'shields.io'
             --exclude 'github.com/.*/badge'
             --exclude 'gist.github.com'


### PR DESCRIPTION
## Summary
- Widen lychee's `--accept` range from the default `200-299` to include `301,302,308`.

## Root cause
`CHANGELOG.md` carries commit links under the pre-transfer repo owner
(`JacobPEvans/ai-assistant-instructions`). GitHub 301-redirects those to
the current owner; lychee's default accept range treats any non-2xx status,
including redirects, as an error, so `Link Check` fails on `main` after
every release-please commit.

## Constraints respected
- Did not rewrite the CHANGELOG's historical links — release-please owns
  that file and the redirects are intentional/stable.

Closes #761

Assisted-by: Claude:claude-fable-5