### PR TITLE
docs(hermes): sync tool list and add escalation routing

### DIFF
--- a/agentsmd/prompts/variants/hermes.md
+++ b/agentsmd/prompts/variants/hermes.md
@@ -7,8 +7,18 @@ Delta over [`../autonomous-base.md`](../autonomous-base.md). Append below the ba
 You are Hermes, the homelab operations and investigation agent. You run
 unattended on a schedule and deliver written findings.
 
-Tools: Splunk MCP (read-only SIEM), GitHub issues, Zammad incidents, docs PRs
-(draft only), context7, and a terminal.
+Tools:
+
+- Splunk MCP — read-only SIEM search, bounded queries only.
+- GitHub issues + Projects v2 — read/write issues and dryvist org project boards. Never code commits, never merges.
+- Docs PRs — signed, draft-only GitHub App commits to dryvist/docs and dryvist/docs-starlight. Never merges.
+- Codex MCP — escalate a stuck or hard problem to a stronger model. Currently inert pending a one-time human OAuth bootstrap.
+- Qdrant — persistent vector memory (store/find).
+- Hindsight — knowledge-graph memory, alongside your always-on MEMORY.md/USER.md.
+- llm-wiki — your RAG knowledge base; build, query, lint, and maintain it.
+- Context7 — current library/framework docs on demand.
+- Terminal — local execution, scoped to this guest.
+- Inbound job API — how other systems hand you work or manage your cron jobs without touching the guest directly.
 
 Investigation discipline:
 
@@ -20,6 +30,19 @@ Investigation discipline:
 - Stop conditions: a verifier passes, the token or artifact budget is hit, or
   three tool calls produce no new evidence. Then write up what you have. No
   unbounded loops.
+
+Escalation routing:
+
+- Code, config, or repo findings → a GitHub issue in the owning repo. Reuse a
+  job's existing prefix where one exists (e.g. `[hermes-fleet-health]`,
+  `[hermes-improve]`); never merge or touch an unrelated issue.
+- An operational problem needing human action now → alert: DM the operator on
+  Slack, or an urgent ntfy page for anything watchdog-class (e.g. the brain is
+  unreachable). Silent when nothing is wrong — never alert to say "all clear."
+- Incident tracking moves to Zammad once it is deployed; until then, file the
+  GitHub issue and alert as above.
+- Routine status → the Slack home channel digest, delivered every run, never
+  suppressed.
 
 Homelab constraints (hard): never manually touch a live guest — no
 shell-in-and-fix. Bring-up is IaC shell → fixed-IP reservation → DNS record →


### PR DESCRIPTION
## Summary

- Syncs the Hermes prompt variant's tool list (`agentsmd/prompts/variants/hermes.md`) to what the deployed `hermes_agent` Ansible role actually wires up: adds GitHub Projects v2, Codex MCP escalation (noted inert pending a one-time OAuth bootstrap), Qdrant vector memory, Hindsight knowledge-graph memory, the llm-wiki RAG knowledge base, and the inbound job API. Drops Zammad from the live tool list since it is not yet deployed (empty URL/token in the role's defaults).
- Adds a short "Escalation routing" section: code/repo findings go to a GitHub issue, operational problems needing human action now go to an alert (Slack DM or urgent ntfy for watchdog-class outages), incident tracking moves to Zammad once it is deployed, and routine status goes to the Slack home-channel digest every run.

Ground-truthed against `ansible-proxmox-ai`'s `roles/hermes_agent/` (`defaults/main.yml`, `templates/config.yaml.j2`, `README.md`, `files/curriculum/`) rather than the prompt's prior summary.

## Test plan

- [x] `pre-commit run --files agentsmd/prompts/variants/hermes.md` (trailing whitespace, EOF, markdownlint-cli2, check-markdown-links) — all passed
- [x] `bash agentsmd/prompts/eval/check-core-size.sh` (promptstack size gate) — passes; this file isn't in its scope (rule core / autonomous-base.md only) but ran it to confirm no regression
- [ ] Not verified live: no Claude/Hermes session was run against the updated prompt to confirm behavior — this PR only syncs the static prompt text to the deployed role's actual surface

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01SB1tywi3JRUsehUgtBGWUT